### PR TITLE
Add `Function` update code path

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-11-16T16:25:06Z"
-  build_hash: f8366f06104baf96f8fe2d1b086ea0ac632318de
+  build_date: "2021-11-19T13:19:34Z"
+  build_hash: dca757058c55b80b4eb20f62f55829981a70f7de
   go_version: go1.16.4
   version: v0.15.2
 api_directory_checksum: 84d93710fb0b89a7ed99b0923611297242a55a99
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.28
 generator_config_info:
-  file_checksum: 1bc55e6356761b977771bdc242b2ddc5bc0e5657
+  file_checksum: 4f4df395ccad50e23ed16cffcf1d4d24a909f9cc
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -12,6 +12,13 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+      # ReservedConcurrentExecutions:
+      #  from:
+      #    operation: PutFunctionConcurrency
+      #    path: ReservedConcurrentExecutions
+      Code:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateFunction:
@@ -23,6 +30,13 @@ resources:
         GetFunction:
           input_fields:
             FunctionName: Name
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateFunction
   Alias:
     fields:
       Name:

--- a/generator.yaml
+++ b/generator.yaml
@@ -12,6 +12,13 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+      # ReservedConcurrentExecutions:
+      #  from:
+      #    operation: PutFunctionConcurrency
+      #    path: ReservedConcurrentExecutions
+      Code:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateFunction:
@@ -23,6 +30,13 @@ resources:
         GetFunction:
           input_fields:
             FunctionName: Name
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateFunction
   Alias:
     fields:
       Name:

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -40,42 +40,8 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
-	if ackcompare.HasNilDifference(a.ko.Spec.Code, b.ko.Spec.Code) {
-		delta.Add("Spec.Code", a.ko.Spec.Code, b.ko.Spec.Code)
-	} else if a.ko.Spec.Code != nil && b.ko.Spec.Code != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI) {
-			delta.Add("Spec.Code.ImageURI", a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI)
-		} else if a.ko.Spec.Code.ImageURI != nil && b.ko.Spec.Code.ImageURI != nil {
-			if *a.ko.Spec.Code.ImageURI != *b.ko.Spec.Code.ImageURI {
-				delta.Add("Spec.Code.ImageURI", a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI)
-			}
-		}
-		if ackcompare.HasNilDifference(a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket) {
-			delta.Add("Spec.Code.S3Bucket", a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket)
-		} else if a.ko.Spec.Code.S3Bucket != nil && b.ko.Spec.Code.S3Bucket != nil {
-			if *a.ko.Spec.Code.S3Bucket != *b.ko.Spec.Code.S3Bucket {
-				delta.Add("Spec.Code.S3Bucket", a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket)
-			}
-		}
-		if ackcompare.HasNilDifference(a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key) {
-			delta.Add("Spec.Code.S3Key", a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key)
-		} else if a.ko.Spec.Code.S3Key != nil && b.ko.Spec.Code.S3Key != nil {
-			if *a.ko.Spec.Code.S3Key != *b.ko.Spec.Code.S3Key {
-				delta.Add("Spec.Code.S3Key", a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key)
-			}
-		}
-		if ackcompare.HasNilDifference(a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion) {
-			delta.Add("Spec.Code.S3ObjectVersion", a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion)
-		} else if a.ko.Spec.Code.S3ObjectVersion != nil && b.ko.Spec.Code.S3ObjectVersion != nil {
-			if *a.ko.Spec.Code.S3ObjectVersion != *b.ko.Spec.Code.S3ObjectVersion {
-				delta.Add("Spec.Code.S3ObjectVersion", a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion)
-			}
-		}
-		if !bytes.Equal(a.ko.Spec.Code.ZipFile, b.ko.Spec.Code.ZipFile) {
-			delta.Add("Spec.Code.ZipFile", a.ko.Spec.Code.ZipFile, b.ko.Spec.Code.ZipFile)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CodeSigningConfigARN, b.ko.Spec.CodeSigningConfigARN) {
 		delta.Add("Spec.CodeSigningConfigARN", a.ko.Spec.CodeSigningConfigARN, b.ko.Spec.CodeSigningConfigARN)
 	} else if a.ko.Spec.CodeSigningConfigARN != nil && b.ko.Spec.CodeSigningConfigARN != nil {

--- a/pkg/resource/function/hooks.go
+++ b/pkg/resource/function/hooks.go
@@ -1,0 +1,348 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package function
+
+import (
+	"context"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	"github.com/aws/aws-sdk-go/aws"
+	svcsdk "github.com/aws/aws-sdk-go/service/lambda"
+)
+
+// customUpdateFunction patches each of the resource properties in the backend AWS
+// service API and returns a new resource with updated fields.
+func (rm *resourceManager) customUpdateFunction(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (*resource, error) {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdateFunction")
+	defer exit(err)
+
+	if delta.DifferentAt("Spec.Code") {
+		err = rm.updateFunctionCode(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if delta.DifferentAt("Spec.Tags") {
+		err = rm.updateFunctionTags(ctx, latest, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if delta.DifferentAt("Spec.Description") ||
+		delta.DifferentAt("Spec.Handler") ||
+		delta.DifferentAt("Spec.KMSKeyARN") ||
+		delta.DifferentAt("Spec.MemorySize") ||
+		delta.DifferentAt("Spec.Role") ||
+		delta.DifferentAt("Spec.Timeout") ||
+		delta.DifferentAt("Spec.Environement") ||
+		delta.DifferentAt("Spec.FileSystemConfigs") ||
+		delta.DifferentAt("Spec.ImageConfig") ||
+		delta.DifferentAt("Spec.TracingConfig") ||
+		delta.DifferentAt("Spec.VPCConfig") {
+		err = rm.updateFunctionConfiguration(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	readOneLatest, err := rm.ReadOne(ctx, desired)
+	if err != nil {
+		return nil, err
+	}
+	return rm.concreteResource(readOneLatest), nil
+}
+
+// updateFunctionConfiguration calls the UpdateFunctionConfiguration to edit a
+// specific lambda function configuration.
+func (rm *resourceManager) updateFunctionConfiguration(
+	ctx context.Context,
+	desired *resource,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateFunctionConfiguration")
+	defer exit(err)
+
+	dspec := desired.ko.Spec
+	input := &svcsdk.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String(*dspec.Name),
+	}
+
+	if dspec.Description != nil {
+		input.Description = aws.String(*dspec.Description)
+	} else {
+		input.Description = aws.String("")
+	}
+
+	if dspec.Handler != nil {
+		input.Handler = aws.String(*dspec.Handler)
+	} else {
+		input.Handler = aws.String("")
+	}
+
+	if dspec.KMSKeyARN != nil {
+		input.KMSKeyArn = aws.String(*dspec.KMSKeyARN)
+	} else {
+		input.KMSKeyArn = aws.String("")
+	}
+
+	if dspec.Role != nil {
+		input.Role = aws.String(*dspec.Role)
+	} else {
+		input.Role = aws.String("")
+	}
+
+	if dspec.MemorySize != nil {
+		input.MemorySize = aws.Int64(*dspec.MemorySize)
+	} else {
+		input.MemorySize = aws.Int64(0)
+	}
+
+	if dspec.Timeout != nil {
+		input.Timeout = aws.Int64(*dspec.Timeout)
+	} else {
+		input.Timeout = aws.Int64(0)
+	}
+
+	environment := &svcsdk.Environment{}
+	if dspec.Environment != nil {
+		environment.Variables = dspec.Environment.DeepCopy().Variables
+
+	}
+	input.Environment = environment
+
+	fileSystemConfigs := []*svcsdk.FileSystemConfig{}
+	if len(dspec.FileSystemConfigs) > 0 {
+		for _, elem := range dspec.FileSystemConfigs {
+			elemCopy := elem.DeepCopy()
+			fscElem := &svcsdk.FileSystemConfig{
+				Arn:            elemCopy.ARN,
+				LocalMountPath: elemCopy.LocalMountPath,
+			}
+			fileSystemConfigs = append(fileSystemConfigs, fscElem)
+		}
+		input.FileSystemConfigs = fileSystemConfigs
+	}
+
+	if dspec.ImageConfig != nil && dspec.Code.ImageURI != nil && *dspec.Code.ImageURI != "" {
+		imageConfig := &svcsdk.ImageConfig{}
+		if dspec.ImageConfig != nil {
+			imageConfigCopy := dspec.ImageConfig.DeepCopy()
+			imageConfig.Command = imageConfigCopy.Command
+			imageConfig.EntryPoint = imageConfigCopy.EntryPoint
+			imageConfig.WorkingDirectory = imageConfigCopy.WorkingDirectory
+		}
+		input.ImageConfig = imageConfig
+	}
+
+	tracingConfig := &svcsdk.TracingConfig{}
+	if dspec.TracingConfig != nil {
+		tracingConfig.Mode = aws.String(*dspec.TracingConfig.Mode)
+	}
+	input.TracingConfig = tracingConfig
+
+	VPCConfig := &svcsdk.VpcConfig{}
+	if dspec.VPCConfig != nil {
+		vpcConfigCopy := dspec.VPCConfig.DeepCopy()
+		VPCConfig.SubnetIds = vpcConfigCopy.SubnetIDs
+		VPCConfig.SecurityGroupIds = vpcConfigCopy.SecurityGroupIDs
+	}
+	input.VpcConfig = VPCConfig
+
+	_, err = rm.sdkapi.UpdateFunctionConfigurationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateFunctionConfiguration", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// updateFunctionsTags uses TagResource and UntagResource to add, remove and update
+// a lambda function tags.
+func (rm *resourceManager) updateFunctionTags(
+	ctx context.Context,
+	latest *resource,
+	desired *resource,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateFunctionTags")
+	defer exit(err)
+
+	added, removed, updated := compareMaps(latest.ko.Spec.Tags, desired.ko.Spec.Tags)
+
+	// There is no api call to update tags, so we need to remove them and add them later
+	// with their new values.
+	if len(removed)+len(updated) > 0 {
+		removeTags := []*string{}
+		for k := range updated {
+			removeTags = append(removeTags, &k)
+		}
+		for _, k := range removed {
+			removeTags = append(removeTags, &k)
+		}
+		input := &svcsdk.UntagResourceInput{
+			Resource: (*string)(desired.ko.Status.ACKResourceMetadata.ARN),
+			TagKeys:  removeTags,
+		}
+		_, err = rm.sdkapi.UntagResourceWithContext(ctx, input)
+		rm.metrics.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(updated)+len(added) > 0 {
+		addedTags := map[string]*string{}
+		for k, v := range added {
+			addedTags[k] = v
+		}
+		for k, v := range updated {
+			addedTags[k] = v
+		}
+
+		input := &svcsdk.TagResourceInput{
+			Resource: (*string)(desired.ko.Status.ACKResourceMetadata.ARN),
+			Tags:     addedTags,
+		}
+		_, err = rm.sdkapi.TagResourceWithContext(ctx, input)
+		rm.metrics.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// updateFunctionsCode calls UpdateFunctionCode to update a specific lambda
+// function code.
+func (rm *resourceManager) updateFunctionCode(
+	ctx context.Context,
+	desired *resource,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateFunctionCode")
+	defer exit(err)
+
+	dspec := desired.ko.Spec
+	input := &svcsdk.UpdateFunctionCodeInput{
+		FunctionName: aws.String(*dspec.Name),
+	}
+
+	if dspec.Code != nil {
+		switch {
+		case dspec.Code.ImageURI != nil:
+			input.ImageUri = dspec.Code.ImageURI
+		case dspec.Code.S3Bucket != nil,
+			dspec.Code.S3Key != nil,
+			dspec.Code.S3ObjectVersion != nil:
+
+			log := ackrtlog.FromContext(ctx)
+			log.Debug("updating code.s3Bucket field is not currently supported.")
+
+			input.S3Bucket = dspec.Code.S3Bucket
+			input.S3Key = dspec.Code.S3Key
+			input.S3ObjectVersion = dspec.Code.S3ObjectVersion
+		}
+	}
+
+	_, err = rm.sdkapi.UpdateFunctionCodeWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateFunctionCode", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// compareMaps compares two string to string maps and returns three outputs: a
+// map of the new key/values observed, a list of the keys of the removed values
+// and a map containing the updated keys and their new values.
+func compareMaps(
+	a map[string]*string,
+	b map[string]*string,
+) (added map[string]*string, removed []string, updated map[string]*string) {
+	added = map[string]*string{}
+	updated = map[string]*string{}
+	visited := make(map[string]bool, len(a))
+	for keyA, valueA := range a {
+		valueB, found := b[keyA]
+		if !found {
+			removed = append(removed, keyA)
+			continue
+		}
+		if *valueA != *valueB {
+			updated[keyA] = valueB
+		}
+		visited[keyA] = true
+	}
+	for keyB, valueB := range b {
+		_, found := a[keyB]
+		if !found {
+			added[keyB] = valueB
+		}
+	}
+	return
+}
+
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if ackcompare.HasNilDifference(a.ko.Spec.Code, b.ko.Spec.Code) {
+		delta.Add("Spec.Code", a.ko.Spec.Code, b.ko.Spec.Code)
+	} else if a.ko.Spec.Code != nil && b.ko.Spec.Code != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI) {
+			delta.Add("Spec.Code.ImageURI", a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI)
+		} else if a.ko.Spec.Code.ImageURI != nil && b.ko.Spec.Code.ImageURI != nil {
+			if *a.ko.Spec.Code.ImageURI != *b.ko.Spec.Code.ImageURI {
+				delta.Add("Spec.Code.ImageURI", a.ko.Spec.Code.ImageURI, b.ko.Spec.Code.ImageURI)
+			}
+		}
+		//TODO(hialylmh) handle Spec.Code.S3bucket changes
+		//  if ackcompare.HasNilDifference(a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket) {
+		//  	delta.Add("Spec.Code.S3Bucket", a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket)
+		//  } else if a.ko.Spec.Code.S3Bucket != nil && b.ko.Spec.Code.S3Bucket != nil {
+		//  	if *a.ko.Spec.Code.S3Bucket != *b.ko.Spec.Code.S3Bucket {
+		//  		delta.Add("Spec.Code.S3Bucket", a.ko.Spec.Code.S3Bucket, b.ko.Spec.Code.S3Bucket)
+		//  	}
+		//  }
+		if ackcompare.HasNilDifference(a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key) {
+			delta.Add("Spec.Code.S3Key", a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key)
+		} else if a.ko.Spec.Code.S3Key != nil && b.ko.Spec.Code.S3Key != nil {
+			if *a.ko.Spec.Code.S3Key != *b.ko.Spec.Code.S3Key {
+				delta.Add("Spec.Code.S3Key", a.ko.Spec.Code.S3Key, b.ko.Spec.Code.S3Key)
+			}
+		}
+		if ackcompare.HasNilDifference(a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion) {
+			delta.Add("Spec.Code.S3ObjectVersion", a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion)
+		} else if a.ko.Spec.Code.S3ObjectVersion != nil && b.ko.Spec.Code.S3ObjectVersion != nil {
+			if *a.ko.Spec.Code.S3ObjectVersion != *b.ko.Spec.Code.S3ObjectVersion {
+				delta.Add("Spec.Code.S3ObjectVersion", a.ko.Spec.Code.S3ObjectVersion, b.ko.Spec.Code.S3ObjectVersion)
+			}
+		}
+	}
+}

--- a/pkg/resource/function/hooks_test.go
+++ b/pkg/resource/function/hooks_test.go
@@ -1,0 +1,100 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package function
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func Test_compareMaps(t *testing.T) {
+	type args struct {
+		a map[string]*string
+		b map[string]*string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantAdded   map[string]*string
+		wantRemoved []string
+		wantUpdated map[string]*string
+	}{
+		{
+			name: "empty maps",
+			args: args{
+				a: map[string]*string{},
+				b: map[string]*string{},
+			},
+			wantAdded:   map[string]*string{},
+			wantRemoved: nil,
+			wantUpdated: map[string]*string{},
+		},
+		{
+			name: "new elements",
+			args: args{
+				a: map[string]*string{},
+				b: map[string]*string{"k1": aws.String("v1")},
+			},
+			wantAdded:   map[string]*string{"k1": aws.String("v1")},
+			wantRemoved: nil,
+			wantUpdated: map[string]*string{},
+		},
+		{
+			name: "updated elements",
+			args: args{
+				a: map[string]*string{"k1": aws.String("v1"), "k2": aws.String("v2")},
+				b: map[string]*string{"k1": aws.String("v10"), "k2": aws.String("v20")},
+			},
+			wantAdded:   map[string]*string{},
+			wantRemoved: nil,
+			wantUpdated: map[string]*string{"k1": aws.String("v10"), "k2": aws.String("v20")},
+		},
+		{
+			name: "removed elements",
+			args: args{
+				a: map[string]*string{"k1": aws.String("v1"), "k2": aws.String("v2")},
+				b: map[string]*string{"k1": aws.String("v1")},
+			},
+			wantAdded:   map[string]*string{},
+			wantRemoved: []string{"k2"},
+			wantUpdated: map[string]*string{},
+		},
+		{
+			name: "added, updated and removed elements",
+			args: args{
+				a: map[string]*string{"k1": aws.String("v1"), "k2": aws.String("v2")},
+				b: map[string]*string{"k1": aws.String("v10"), "k3": aws.String("v3")},
+			},
+			wantAdded:   map[string]*string{"k3": aws.String("v3")},
+			wantRemoved: []string{"k2"},
+			wantUpdated: map[string]*string{"k1": aws.String("v10")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdded, gotRemoved, gotUpdated := compareMaps(tt.args.a, tt.args.b)
+			if !reflect.DeepEqual(gotAdded, tt.wantAdded) {
+				t.Errorf("compareMaps() gotAdded = %v, want %v", gotAdded, tt.wantAdded)
+			}
+			if !reflect.DeepEqual(gotRemoved, tt.wantRemoved) {
+				t.Errorf("compareMaps() gotRemoved = %v, want %v", gotRemoved, tt.wantRemoved)
+			}
+			if !reflect.DeepEqual(gotUpdated, tt.wantUpdated) {
+				t.Errorf("compareMaps() gotUpdated = %v, want %v", gotUpdated, tt.wantUpdated)
+			}
+		})
+	}
+}

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -102,6 +102,244 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if resp.Configuration.CodeSha256 != nil {
+		ko.Status.CodeSHA256 = resp.Configuration.CodeSha256
+	} else {
+		ko.Status.CodeSHA256 = nil
+	}
+	if resp.Configuration.CodeSize != nil {
+		ko.Status.CodeSize = resp.Configuration.CodeSize
+	} else {
+		ko.Status.CodeSize = nil
+	}
+	if resp.Configuration.DeadLetterConfig != nil {
+		f2 := &svcapitypes.DeadLetterConfig{}
+		if resp.Configuration.DeadLetterConfig.TargetArn != nil {
+			f2.TargetARN = resp.Configuration.DeadLetterConfig.TargetArn
+		}
+		ko.Spec.DeadLetterConfig = f2
+	} else {
+		ko.Spec.DeadLetterConfig = nil
+	}
+	if resp.Configuration.Description != nil {
+		ko.Spec.Description = resp.Configuration.Description
+	} else {
+		ko.Spec.Description = nil
+	}
+	if resp.Configuration.Environment != nil {
+		f4 := &svcapitypes.Environment{}
+		if resp.Configuration.Environment.Variables != nil {
+			f4f1 := map[string]*string{}
+			for f4f1key, f4f1valiter := range resp.Configuration.Environment.Variables {
+				var f4f1val string
+				f4f1val = *f4f1valiter
+				f4f1[f4f1key] = &f4f1val
+			}
+			f4.Variables = f4f1
+		}
+		ko.Spec.Environment = f4
+	} else {
+		ko.Spec.Environment = nil
+	}
+	if resp.Configuration.FileSystemConfigs != nil {
+		f5 := []*svcapitypes.FileSystemConfig{}
+		for _, f5iter := range resp.Configuration.FileSystemConfigs {
+			f5elem := &svcapitypes.FileSystemConfig{}
+			if f5iter.Arn != nil {
+				f5elem.ARN = f5iter.Arn
+			}
+			if f5iter.LocalMountPath != nil {
+				f5elem.LocalMountPath = f5iter.LocalMountPath
+			}
+			f5 = append(f5, f5elem)
+		}
+		ko.Spec.FileSystemConfigs = f5
+	} else {
+		ko.Spec.FileSystemConfigs = nil
+	}
+
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.Configuration.FunctionArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.Configuration.FunctionArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+	if resp.Configuration.FunctionName != nil {
+		ko.Spec.Name = resp.Configuration.FunctionName
+	} else {
+		ko.Spec.Name = nil
+	}
+	if resp.Configuration.Handler != nil {
+		ko.Spec.Handler = resp.Configuration.Handler
+	} else {
+		ko.Spec.Handler = nil
+	}
+	if resp.Configuration.ImageConfigResponse != nil {
+		f9 := &svcapitypes.ImageConfigResponse{}
+		if resp.Configuration.ImageConfigResponse.Error != nil {
+			f9f0 := &svcapitypes.ImageConfigError{}
+			if resp.Configuration.ImageConfigResponse.Error.ErrorCode != nil {
+				f9f0.ErrorCode = resp.Configuration.ImageConfigResponse.Error.ErrorCode
+			}
+			if resp.Configuration.ImageConfigResponse.Error.Message != nil {
+				f9f0.Message = resp.Configuration.ImageConfigResponse.Error.Message
+			}
+			f9.Error = f9f0
+		}
+		if resp.Configuration.ImageConfigResponse.ImageConfig != nil {
+			f9f1 := &svcapitypes.ImageConfig{}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.Command != nil {
+				f9f1f0 := []*string{}
+				for _, f9f1f0iter := range resp.Configuration.ImageConfigResponse.ImageConfig.Command {
+					var f9f1f0elem string
+					f9f1f0elem = *f9f1f0iter
+					f9f1f0 = append(f9f1f0, &f9f1f0elem)
+				}
+				f9f1.Command = f9f1f0
+			}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.EntryPoint != nil {
+				f9f1f1 := []*string{}
+				for _, f9f1f1iter := range resp.Configuration.ImageConfigResponse.ImageConfig.EntryPoint {
+					var f9f1f1elem string
+					f9f1f1elem = *f9f1f1iter
+					f9f1f1 = append(f9f1f1, &f9f1f1elem)
+				}
+				f9f1.EntryPoint = f9f1f1
+			}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.WorkingDirectory != nil {
+				f9f1.WorkingDirectory = resp.Configuration.ImageConfigResponse.ImageConfig.WorkingDirectory
+			}
+			f9.ImageConfig = f9f1
+		}
+		ko.Status.ImageConfigResponse = f9
+	} else {
+		ko.Status.ImageConfigResponse = nil
+	}
+	if resp.Configuration.KMSKeyArn != nil {
+		ko.Spec.KMSKeyARN = resp.Configuration.KMSKeyArn
+	} else {
+		ko.Spec.KMSKeyARN = nil
+	}
+	if resp.Configuration.LastModified != nil {
+		ko.Status.LastModified = resp.Configuration.LastModified
+	} else {
+		ko.Status.LastModified = nil
+	}
+	if resp.Configuration.LastUpdateStatus != nil {
+		ko.Status.LastUpdateStatus = resp.Configuration.LastUpdateStatus
+	} else {
+		ko.Status.LastUpdateStatus = nil
+	}
+	if resp.Configuration.LastUpdateStatusReason != nil {
+		ko.Status.LastUpdateStatusReason = resp.Configuration.LastUpdateStatusReason
+	} else {
+		ko.Status.LastUpdateStatusReason = nil
+	}
+	if resp.Configuration.LastUpdateStatusReasonCode != nil {
+		ko.Status.LastUpdateStatusReasonCode = resp.Configuration.LastUpdateStatusReasonCode
+	} else {
+		ko.Status.LastUpdateStatusReasonCode = nil
+	}
+
+	if resp.Configuration.MasterArn != nil {
+		ko.Status.MasterARN = resp.Configuration.MasterArn
+	} else {
+		ko.Status.MasterARN = nil
+	}
+	if resp.Configuration.MemorySize != nil {
+		ko.Spec.MemorySize = resp.Configuration.MemorySize
+	} else {
+		ko.Spec.MemorySize = nil
+	}
+	if resp.Configuration.PackageType != nil {
+		ko.Spec.PackageType = resp.Configuration.PackageType
+	} else {
+		ko.Spec.PackageType = nil
+	}
+	if resp.Configuration.RevisionId != nil {
+		ko.Status.RevisionID = resp.Configuration.RevisionId
+	} else {
+		ko.Status.RevisionID = nil
+	}
+	if resp.Configuration.Role != nil {
+		ko.Spec.Role = resp.Configuration.Role
+	} else {
+		ko.Spec.Role = nil
+	}
+	if resp.Configuration.Runtime != nil {
+		ko.Spec.Runtime = resp.Configuration.Runtime
+	} else {
+		ko.Spec.Runtime = nil
+	}
+	if resp.Configuration.SigningJobArn != nil {
+		ko.Status.SigningJobARN = resp.Configuration.SigningJobArn
+	} else {
+		ko.Status.SigningJobARN = nil
+	}
+	if resp.Configuration.SigningProfileVersionArn != nil {
+		ko.Status.SigningProfileVersionARN = resp.Configuration.SigningProfileVersionArn
+	} else {
+		ko.Status.SigningProfileVersionARN = nil
+	}
+	if resp.Configuration.State != nil {
+		ko.Status.State = resp.Configuration.State
+	} else {
+		ko.Status.State = nil
+	}
+	if resp.Configuration.StateReason != nil {
+		ko.Status.StateReason = resp.Configuration.StateReason
+	} else {
+		ko.Status.StateReason = nil
+	}
+	if resp.Configuration.StateReasonCode != nil {
+		ko.Status.StateReasonCode = resp.Configuration.StateReasonCode
+	} else {
+		ko.Status.StateReasonCode = nil
+	}
+	if resp.Configuration.Timeout != nil {
+		ko.Spec.Timeout = resp.Configuration.Timeout
+	} else {
+		ko.Spec.Timeout = nil
+	}
+	if resp.Configuration.TracingConfig != nil {
+		f28 := &svcapitypes.TracingConfig{}
+		if resp.Configuration.TracingConfig.Mode != nil {
+			f28.Mode = resp.Configuration.TracingConfig.Mode
+		}
+		ko.Spec.TracingConfig = f28
+	} else {
+		ko.Spec.TracingConfig = nil
+	}
+	if resp.Configuration.Version != nil {
+		ko.Status.Version = resp.Configuration.Version
+	} else {
+		ko.Status.Version = nil
+	}
+	if resp.Configuration.VpcConfig != nil {
+		f30 := &svcapitypes.VPCConfig{}
+		if resp.Configuration.VpcConfig.SecurityGroupIds != nil {
+			f30f0 := []*string{}
+			for _, f30f0iter := range resp.Configuration.VpcConfig.SecurityGroupIds {
+				var f30f0elem string
+				f30f0elem = *f30f0iter
+				f30f0 = append(f30f0, &f30f0elem)
+			}
+			f30.SecurityGroupIDs = f30f0
+		}
+		if resp.Configuration.VpcConfig.SubnetIds != nil {
+			f30f1 := []*string{}
+			for _, f30f1iter := range resp.Configuration.VpcConfig.SubnetIds {
+				var f30f1elem string
+				f30f1elem = *f30f1iter
+				f30f1 = append(f30f1, &f30f1elem)
+			}
+			f30.SubnetIDs = f30f1
+		}
+		ko.Spec.VPCConfig = f30
+	} else {
+		ko.Spec.VPCConfig = nil
+	}
 	return &resource{ko}, nil
 }
 
@@ -587,8 +825,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateFunction(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,238 @@
+	if resp.Configuration.CodeSha256 != nil {
+		ko.Status.CodeSHA256 = resp.Configuration.CodeSha256
+	} else {
+		ko.Status.CodeSHA256 = nil
+	}
+	if resp.Configuration.CodeSize != nil {
+		ko.Status.CodeSize = resp.Configuration.CodeSize
+	} else {
+		ko.Status.CodeSize = nil
+	}
+	if resp.Configuration.DeadLetterConfig != nil {
+		f2 := &svcapitypes.DeadLetterConfig{}
+		if resp.Configuration.DeadLetterConfig.TargetArn != nil {
+			f2.TargetARN = resp.Configuration.DeadLetterConfig.TargetArn
+		}
+		ko.Spec.DeadLetterConfig = f2
+	} else {
+		ko.Spec.DeadLetterConfig = nil
+	}
+	if resp.Configuration.Description != nil {
+		ko.Spec.Description = resp.Configuration.Description
+	} else {
+		ko.Spec.Description = nil
+	}
+	if resp.Configuration.Environment != nil {
+		f4 := &svcapitypes.Environment{}
+		if resp.Configuration.Environment.Variables != nil {
+			f4f1 := map[string]*string{}
+			for f4f1key, f4f1valiter := range resp.Configuration.Environment.Variables {
+				var f4f1val string
+				f4f1val = *f4f1valiter
+				f4f1[f4f1key] = &f4f1val
+			}
+			f4.Variables = f4f1
+		}
+		ko.Spec.Environment = f4
+	} else {
+		ko.Spec.Environment = nil
+	}
+	if resp.Configuration.FileSystemConfigs != nil {
+		f5 := []*svcapitypes.FileSystemConfig{}
+		for _, f5iter := range resp.Configuration.FileSystemConfigs {
+			f5elem := &svcapitypes.FileSystemConfig{}
+			if f5iter.Arn != nil {
+				f5elem.ARN = f5iter.Arn
+			}
+			if f5iter.LocalMountPath != nil {
+				f5elem.LocalMountPath = f5iter.LocalMountPath
+			}
+			f5 = append(f5, f5elem)
+		}
+		ko.Spec.FileSystemConfigs = f5
+	} else {
+		ko.Spec.FileSystemConfigs = nil
+	}
+
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.Configuration.FunctionArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.Configuration.FunctionArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+	if resp.Configuration.FunctionName != nil {
+		ko.Spec.Name = resp.Configuration.FunctionName
+	} else {
+		ko.Spec.Name = nil
+	}
+	if resp.Configuration.Handler != nil {
+		ko.Spec.Handler = resp.Configuration.Handler
+	} else {
+		ko.Spec.Handler = nil
+	}
+	if resp.Configuration.ImageConfigResponse != nil {
+		f9 := &svcapitypes.ImageConfigResponse{}
+		if resp.Configuration.ImageConfigResponse.Error != nil {
+			f9f0 := &svcapitypes.ImageConfigError{}
+			if resp.Configuration.ImageConfigResponse.Error.ErrorCode != nil {
+				f9f0.ErrorCode = resp.Configuration.ImageConfigResponse.Error.ErrorCode
+			}
+			if resp.Configuration.ImageConfigResponse.Error.Message != nil {
+				f9f0.Message = resp.Configuration.ImageConfigResponse.Error.Message
+			}
+			f9.Error = f9f0
+		}
+		if resp.Configuration.ImageConfigResponse.ImageConfig != nil {
+			f9f1 := &svcapitypes.ImageConfig{}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.Command != nil {
+				f9f1f0 := []*string{}
+				for _, f9f1f0iter := range resp.Configuration.ImageConfigResponse.ImageConfig.Command {
+					var f9f1f0elem string
+					f9f1f0elem = *f9f1f0iter
+					f9f1f0 = append(f9f1f0, &f9f1f0elem)
+				}
+				f9f1.Command = f9f1f0
+			}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.EntryPoint != nil {
+				f9f1f1 := []*string{}
+				for _, f9f1f1iter := range resp.Configuration.ImageConfigResponse.ImageConfig.EntryPoint {
+					var f9f1f1elem string
+					f9f1f1elem = *f9f1f1iter
+					f9f1f1 = append(f9f1f1, &f9f1f1elem)
+				}
+				f9f1.EntryPoint = f9f1f1
+			}
+			if resp.Configuration.ImageConfigResponse.ImageConfig.WorkingDirectory != nil {
+				f9f1.WorkingDirectory = resp.Configuration.ImageConfigResponse.ImageConfig.WorkingDirectory
+			}
+			f9.ImageConfig = f9f1
+		}
+		ko.Status.ImageConfigResponse = f9
+	} else {
+		ko.Status.ImageConfigResponse = nil
+	}
+	if resp.Configuration.KMSKeyArn != nil {
+		ko.Spec.KMSKeyARN = resp.Configuration.KMSKeyArn
+	} else {
+		ko.Spec.KMSKeyARN = nil
+	}
+	if resp.Configuration.LastModified != nil {
+		ko.Status.LastModified = resp.Configuration.LastModified
+	} else {
+		ko.Status.LastModified = nil
+	}
+	if resp.Configuration.LastUpdateStatus != nil {
+		ko.Status.LastUpdateStatus = resp.Configuration.LastUpdateStatus
+	} else {
+		ko.Status.LastUpdateStatus = nil
+	}
+	if resp.Configuration.LastUpdateStatusReason != nil {
+		ko.Status.LastUpdateStatusReason = resp.Configuration.LastUpdateStatusReason
+	} else {
+		ko.Status.LastUpdateStatusReason = nil
+	}
+	if resp.Configuration.LastUpdateStatusReasonCode != nil {
+		ko.Status.LastUpdateStatusReasonCode = resp.Configuration.LastUpdateStatusReasonCode
+	} else {
+		ko.Status.LastUpdateStatusReasonCode = nil
+	}
+
+	if resp.Configuration.MasterArn != nil {
+		ko.Status.MasterARN = resp.Configuration.MasterArn
+	} else {
+		ko.Status.MasterARN = nil
+	}
+	if resp.Configuration.MemorySize != nil {
+		ko.Spec.MemorySize = resp.Configuration.MemorySize
+	} else {
+		ko.Spec.MemorySize = nil
+	}
+	if resp.Configuration.PackageType != nil {
+		ko.Spec.PackageType = resp.Configuration.PackageType
+	} else {
+		ko.Spec.PackageType = nil
+	}
+	if resp.Configuration.RevisionId != nil {
+		ko.Status.RevisionID = resp.Configuration.RevisionId
+	} else {
+		ko.Status.RevisionID = nil
+	}
+	if resp.Configuration.Role != nil {
+		ko.Spec.Role = resp.Configuration.Role
+	} else {
+		ko.Spec.Role = nil
+	}
+	if resp.Configuration.Runtime != nil {
+		ko.Spec.Runtime = resp.Configuration.Runtime
+	} else {
+		ko.Spec.Runtime = nil
+	}
+	if resp.Configuration.SigningJobArn != nil {
+		ko.Status.SigningJobARN = resp.Configuration.SigningJobArn
+	} else {
+		ko.Status.SigningJobARN = nil
+	}
+	if resp.Configuration.SigningProfileVersionArn != nil {
+		ko.Status.SigningProfileVersionARN = resp.Configuration.SigningProfileVersionArn
+	} else {
+		ko.Status.SigningProfileVersionARN = nil
+	}
+	if resp.Configuration.State != nil {
+		ko.Status.State = resp.Configuration.State
+	} else {
+		ko.Status.State = nil
+	}
+	if resp.Configuration.StateReason != nil {
+		ko.Status.StateReason = resp.Configuration.StateReason
+	} else {
+		ko.Status.StateReason = nil
+	}
+	if resp.Configuration.StateReasonCode != nil {
+		ko.Status.StateReasonCode = resp.Configuration.StateReasonCode
+	} else {
+		ko.Status.StateReasonCode = nil
+	}
+	if resp.Configuration.Timeout != nil {
+		ko.Spec.Timeout = resp.Configuration.Timeout
+	} else {
+		ko.Spec.Timeout = nil
+	}
+	if resp.Configuration.TracingConfig != nil {
+		f28 := &svcapitypes.TracingConfig{}
+		if resp.Configuration.TracingConfig.Mode != nil {
+			f28.Mode = resp.Configuration.TracingConfig.Mode
+		}
+		ko.Spec.TracingConfig = f28
+	} else {
+		ko.Spec.TracingConfig = nil
+	}
+	if resp.Configuration.Version != nil {
+		ko.Status.Version = resp.Configuration.Version
+	} else {
+		ko.Status.Version = nil
+	}
+	if resp.Configuration.VpcConfig != nil {
+		f30 := &svcapitypes.VPCConfig{}
+		if resp.Configuration.VpcConfig.SecurityGroupIds != nil {
+			f30f0 := []*string{}
+			for _, f30f0iter := range resp.Configuration.VpcConfig.SecurityGroupIds {
+				var f30f0elem string
+				f30f0elem = *f30f0iter
+				f30f0 = append(f30f0, &f30f0elem)
+			}
+			f30.SecurityGroupIDs = f30f0
+		}
+		if resp.Configuration.VpcConfig.SubnetIds != nil {
+			f30f1 := []*string{}
+			for _, f30f1iter := range resp.Configuration.VpcConfig.SubnetIds {
+				var f30f1elem string
+				f30f1elem = *f30f1iter
+				f30f1 = append(f30f1, &f30f1elem)
+			}
+			f30.SubnetIDs = f30f1
+		}
+		ko.Spec.VPCConfig = f30
+	} else {
+		ko.Spec.VPCConfig = nil
+	}


### PR DESCRIPTION
Issue aws-controllers-k8s/community#1062

Adds support for updating `Function` resources

Description of changes:
- Add custom code to properly make update calls for functions
- Add custom delta pre compare code to ignore `spec.code.s3Bucket`
changes
- Add an `sdk_read_one_post_set_output` hook to add missing fields
at the set_output part.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
