### PR TITLE
Add `reservedConcurrentExecutions` field for `Function` Resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-11-19T13:19:34Z"
+  build_date: "2021-11-23T23:35:17Z"
   build_hash: dca757058c55b80b4eb20f62f55829981a70f7de
   go_version: go1.16.4
   version: v0.15.2
-api_directory_checksum: 84d93710fb0b89a7ed99b0923611297242a55a99
+api_directory_checksum: a3c5e80eca3fc5591e8a0a2763d048f2ed4a6ddd
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.28
 generator_config_info:
-  file_checksum: 4f4df395ccad50e23ed16cffcf1d4d24a909f9cc
+  file_checksum: 47d63e3b8348d4f33111e6a3cbd6eca2412e9b46
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/function.go
+++ b/apis/v1alpha1/function.go
@@ -74,6 +74,8 @@ type FunctionSpec struct {
 	PackageType *string `json:"packageType,omitempty"`
 	// Set to true to publish the first version of the function during creation.
 	Publish *bool `json:"publish,omitempty"`
+	// The number of simultaneous executions to reserve for the function.
+	ReservedConcurrentExecutions *int64 `json:"reservedConcurrentExecutions,omitempty"`
 	// The Amazon Resource Name (ARN) of the function's execution role.
 	// +kubebuilder:validation:Required
 	Role *string `json:"role"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -12,10 +12,10 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
-      # ReservedConcurrentExecutions:
-      #  from:
-      #    operation: PutFunctionConcurrency
-      #    path: ReservedConcurrentExecutions
+      ReservedConcurrentExecutions:
+        from:
+          operation: PutFunctionConcurrency
+          path: ReservedConcurrentExecutions
       Code:
         compare:
           is_ignored: true

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1483,6 +1483,11 @@ func (in *FunctionSpec) DeepCopyInto(out *FunctionSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ReservedConcurrentExecutions != nil {
+		in, out := &in.ReservedConcurrentExecutions, &out.ReservedConcurrentExecutions
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Role != nil {
 		in, out := &in.Role, &out.Role
 		*out = new(string)

--- a/config/crd/bases/lambda.services.k8s.aws_functions.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functions.yaml
@@ -137,6 +137,11 @@ spec:
                 description: Set to true to publish the first version of the function
                   during creation.
                 type: boolean
+              reservedConcurrentExecutions:
+                description: The number of simultaneous executions to reserve for
+                  the function.
+                format: int64
+                type: integer
               role:
                 description: The Amazon Resource Name (ARN) of the function's execution
                   role.

--- a/generator.yaml
+++ b/generator.yaml
@@ -12,10 +12,10 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
-      # ReservedConcurrentExecutions:
-      #  from:
-      #    operation: PutFunctionConcurrency
-      #    path: ReservedConcurrentExecutions
+      ReservedConcurrentExecutions:
+        from:
+          operation: PutFunctionConcurrency
+          path: ReservedConcurrentExecutions
       Code:
         compare:
           is_ignored: true

--- a/helm/crds/lambda.services.k8s.aws_functions.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functions.yaml
@@ -137,6 +137,11 @@ spec:
                 description: Set to true to publish the first version of the function
                   during creation.
                 type: boolean
+              reservedConcurrentExecutions:
+                description: The number of simultaneous executions to reserve for
+                  the function.
+                format: int64
+                type: integer
               role:
                 description: The Amazon Resource Name (ARN) of the function's execution
                   role.

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -140,6 +140,13 @@ func newResourceDelta(
 			delta.Add("Spec.Publish", a.ko.Spec.Publish, b.ko.Spec.Publish)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.ReservedConcurrentExecutions, b.ko.Spec.ReservedConcurrentExecutions) {
+		delta.Add("Spec.ReservedConcurrentExecutions", a.ko.Spec.ReservedConcurrentExecutions, b.ko.Spec.ReservedConcurrentExecutions)
+	} else if a.ko.Spec.ReservedConcurrentExecutions != nil && b.ko.Spec.ReservedConcurrentExecutions != nil {
+		if *a.ko.Spec.ReservedConcurrentExecutions != *b.ko.Spec.ReservedConcurrentExecutions {
+			delta.Add("Spec.ReservedConcurrentExecutions", a.ko.Spec.ReservedConcurrentExecutions, b.ko.Spec.ReservedConcurrentExecutions)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Role, b.ko.Spec.Role) {
 		delta.Add("Spec.Role", a.ko.Spec.Role, b.ko.Spec.Role)
 	} else if a.ko.Spec.Role != nil && b.ko.Spec.Role != nil {

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -340,6 +340,9 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Spec.VPCConfig = nil
 	}
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
@@ -236,3 +236,6 @@
 	} else {
 		ko.Spec.VPCConfig = nil
 	}
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}

--- a/test/e2e/resources/function.yaml
+++ b/test/e2e/resources/function.yaml
@@ -13,3 +13,4 @@ spec:
   runtime: python3.9
   handler: main
   description: function created by ACK lambda-controller e2e tests
+  reservedConcurrentExecutions: $RESERVED_CONCURRENT_EXECUTIONS

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -47,6 +47,7 @@ def lambda_function():
         replacements["BUCKET_NAME"] = resources.FunctionsBucketName
         replacements["LAMBDA_ROLE"] = resources.LambdaBasicRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
+        replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
         replacements["AWS_REGION"] = get_region()
 
         # Load function CR

--- a/test/e2e/tests/test_event_source_mapping.py
+++ b/test/e2e/tests/test_event_source_mapping.py
@@ -47,6 +47,7 @@ def lambda_function():
         replacements["BUCKET_NAME"] = resources.FunctionsBucketName
         replacements["LAMBDA_ROLE"] = resources.LambdaESMRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
+        replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
         replacements["AWS_REGION"] = get_region()
 
         # Load function CR


### PR DESCRIPTION
The AWS Lambda API support setting up reserved concurrent executions for
a lambda functions. This patch adds a new field to allow users to set the
concurrency configuration for functions.

Description of changes:
- Add `reservedConcurrentExecutions` fields for `Function` Resource
- Add a new e2e test case to specifically test update and create
operations on function resources with a non-nil
`reservedConcurrentExecutions`

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
