### PR TITLE
Support functions `CodeSigningConfig` updates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-11-23T23:35:17Z"
-  build_hash: dca757058c55b80b4eb20f62f55829981a70f7de
+  build_date: "2021-12-20T13:43:11Z"
+  build_hash: 6f17f51682dc0d16c36aa456fd22855ce9282fbc
   go_version: go1.16.4
   version: v0.15.2
 api_directory_checksum: a3c5e80eca3fc5591e8a0a2763d048f2ed4a6ddd
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.28
 generator_config_info:
-  file_checksum: 47d63e3b8348d4f33111e6a3cbd6eca2412e9b46
+  file_checksum: f04b298afa1fd7fd3980226d52412de9ca1523d4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_build_request:
+        template_path: hooks/function/sdk_create_post_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateFunction
   Alias:

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_build_request:
+        template_path: hooks/function/sdk_create_post_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateFunction
   Alias:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -75,3 +75,12 @@ spec:
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if .Values.deployment.tolerations -}}
+      tolerations: {{ toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.affinity -}}
+      affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.priorityClassName -}}
+      priorityClassName: {{ .Values.deployment.priorityClassName -}}
+      {{ end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,9 +15,20 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  # Which nodeSelector to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
-
+  # Which tolerations to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: {}
+  # What affinity to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  # Which priorityClassName to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+  priorityClassName:
+  
 metrics:
   service:
     # Set to true to automatically create a Kubernetes Service resource for the

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -384,6 +384,9 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+	if desired.ko.Spec.CodeSigningConfigARN != nil && *desired.ko.Spec.CodeSigningConfigARN == "" {
+		input.CodeSigningConfigArn = nil
+	}
 
 	var resp *svcsdk.FunctionConfiguration
 	_ = resp

--- a/templates/hooks/function/sdk_create_post_build_request.go.tpl
+++ b/templates/hooks/function/sdk_create_post_build_request.go.tpl
@@ -1,0 +1,3 @@
+	if desired.ko.Spec.CodeSigningConfigARN != nil && *desired.ko.Spec.CodeSigningConfigARN == "" {
+		input.CodeSigningConfigArn = nil
+	}

--- a/test/e2e/resources/function.yaml
+++ b/test/e2e/resources/function.yaml
@@ -14,3 +14,4 @@ spec:
   handler: main
   description: function created by ACK lambda-controller e2e tests
   reservedConcurrentExecutions: $RESERVED_CONCURRENT_EXECUTIONS
+  codeSigningConfigARN: "$CODE_SIGNING_CONFIG_ARN"

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -76,15 +76,15 @@ def clean_up_and_delete_bucket(bucket_name: str):
 
 def delete_sqs_queue(queue_url: str) -> str:
     region = get_region()
-    sqs_client = boto3.resource('sqs', region_name=region)
-    sqs_client.meta.client.delete_queue(
+    sqs_client = boto3.client('sqs', region_name=region)
+    sqs_client.delete_queue(
         QueueUrl=queue_url,
     )
     logging.info(f"Deleted SQS queue {queue_url}")
 
 def delete_dynamodb_table(table_name: str) -> str:
     region = get_region()
-    ddb_client = boto3.resource('dynamodb', region_name=region)
+    ddb_client = boto3.client('dynamodb', region_name=region)
     ddb_client.delete_table(
         TableName=table_name,
     )

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -48,6 +48,7 @@ def lambda_function():
         replacements["LAMBDA_ROLE"] = resources.LambdaBasicRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
         replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = ""
         replacements["AWS_REGION"] = get_region()
 
         # Load function CR

--- a/test/e2e/tests/test_event_source_mapping.py
+++ b/test/e2e/tests/test_event_source_mapping.py
@@ -48,6 +48,7 @@ def lambda_function():
         replacements["LAMBDA_ROLE"] = resources.LambdaESMRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
         replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = ""
         replacements["AWS_REGION"] = get_region()
 
         # Load function CR

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -29,18 +29,55 @@ from e2e.bootstrap_resources import get_bootstrap_resources
 
 RESOURCE_PLURAL = "functions"
 
-CREATE_WAIT_AFTER_SECONDS = 10
-UPDATE_WAIT_AFTER_SECONDS = 10
-DELETE_WAIT_AFTER_SECONDS = 10
+CREATE_WAIT_AFTER_SECONDS = 25
+UPDATE_WAIT_AFTER_SECONDS = 25
+DELETE_WAIT_AFTER_SECONDS = 25
 
 @pytest.fixture(scope="module")
 def lambda_client():
     return boto3.client("lambda")
 
+@pytest.fixture(scope="module")
+def code_signing_config():
+        resource_name = random_suffix_name("lambda-csc", 24)
+
+        resources = get_bootstrap_resources()
+        logging.debug(resources)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["AWS_REGION"] = get_region()
+        replacements["CODE_SIGNING_CONFIG_NAME"] = resource_name
+        replacements["SIGNING_PROFILE_VERSION_ARN"] = resources.SigningProfileVersionArn
+
+        # Load Lambda CR
+        resource_data = load_lambda_resource(
+            "code_signing_config",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, "codesigningconfigs",
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        yield (ref, cr)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted
+
+
 @service_marker
 @pytest.mark.canary
 class TestFunction:
-
     def get_function(self, lambda_client, function_name: str) -> dict:
         try:
             resp = lambda_client.get_function(
@@ -63,6 +100,17 @@ class TestFunction:
             logging.debug(e)
             return None
 
+    def get_function_code_signing_config(self, lambda_client, function_name: str) -> int:
+        try:
+            resp = lambda_client.get_function_code_signing_config(
+                FunctionName=function_name
+            )
+            return resp['CodeSigningConfigArn']
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
     def function_exists(self, lambda_client, function_name: str) -> bool:
         return self.get_function(lambda_client, function_name) is not None
 
@@ -78,6 +126,7 @@ class TestFunction:
         replacements["LAMBDA_ROLE"] = resources.LambdaBasicRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
         replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = ""
         replacements["AWS_REGION"] = get_region()
 
         # Load Lambda CR
@@ -99,6 +148,8 @@ class TestFunction:
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
 
         # Check Lambda function exists
         exists = self.function_exists(lambda_client, resource_name)
@@ -145,6 +196,7 @@ class TestFunction:
         replacements["LAMBDA_ROLE"] = resources.LambdaBasicRoleARN
         replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
         replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "2"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = ""
         replacements["AWS_REGION"] = get_region()
 
         # Load Lambda CR
@@ -167,6 +219,8 @@ class TestFunction:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
         # Check Lambda function exists
         exists = self.function_exists(lambda_client, resource_name)
         assert exists
@@ -184,6 +238,71 @@ class TestFunction:
         # Check function updated fields
         reservedConcurrentExecutions = self.get_function_concurrency(lambda_client, resource_name)
         assert reservedConcurrentExecutions == 0
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check Lambda function doesn't exist
+        exists = self.function_exists(lambda_client, resource_name)
+        assert not exists
+
+    def test_function_code_signing_config(self, lambda_client, code_signing_config):
+        (_, csc_resource) = code_signing_config
+        code_signing_config_arn = csc_resource["status"]["ackResourceMetadata"]["arn"]
+        resource_name = random_suffix_name("lambda-function", 24)
+
+        resources = get_bootstrap_resources()
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["FUNCTION_NAME"] = resource_name
+        replacements["BUCKET_NAME"] = resources.FunctionsBucketName
+        replacements["LAMBDA_ROLE"] = resources.LambdaBasicRoleARN
+        replacements["LAMBDA_FILE_NAME"] = resources.LambdaFunctionFileZip
+        replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "2"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = code_signing_config_arn
+        replacements["AWS_REGION"] = get_region()
+
+        # Load Lambda CR
+        resource_data = load_lambda_resource(
+            "function",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        # Check Lambda function exists
+        exists = self.function_exists(lambda_client, resource_name)
+        assert exists
+
+        # Check function code signing config is correct
+        function_csc_arn = self.get_function_code_signing_config(lambda_client, resource_name)
+        assert function_csc_arn == code_signing_config_arn
+
+        # Delete function code signing config
+        cr["spec"]["codeSigningConfigARN"] = ""
+        k8s.patch_custom_resource(ref, cr)
+
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        function_csc_arn = self.get_function_code_signing_config(lambda_client, resource_name)
+        assert function_csc_arn is None
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)


### PR DESCRIPTION
Issue #, if available:

This patch essentially adds support for updating `CodeSigningConfig` for
lambda functions. This patch also fixes a bug where the controller
tries to update a function that is in a Pending state - the fix is done
by re-queuing whenever a `Status.State` is 'Pending'. Along the way, this
this patch also fixes few existing issues with the current e2e tests.

Description of changes:
- Requeue whenever `Function.Status.State` is `Pending`
- Do not try to update function code if only `code.s3Key` is modified
- Add a hook to prevent the create code path from trying to delete the
code signing config when it's given as an empty string
- Fixes a bug where created dynamodb tables were not deleted
- Fixes a bug where the cr used in the e2e tests were not completely up
to date and need to be refetched

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.