### PR TITLE
Prevent `GetFunctionCodeSigningConfig` calls when a functions packageType is `Image`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-27T16:40:07Z"
-  build_hash: 141cb9db73f881228ea20e572de3ba9df19d5b6f
+  build_date: "2022-05-13T16:30:20Z"
+  build_hash: 302c31fcf0cb7eacf535af8a65569882b3ee0d7c
   go_version: go1.18.1
-  version: v0.18.4-4-g141cb9d-dirty
+  version: v0.18.4-3-g302c31f
 api_directory_checksum: 7c4e0f8971a8ab06389e98b21c00eddad87366f3
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: c48a2acfc8da0b28ee9b81745b9af773d10c7f71
+  file_checksum: 2559b6bfec9b6a5155e6119d9c649a8a4586b188
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -37,6 +37,9 @@ resources:
         GetFunction:
           input_fields:
             FunctionName: Name
+    exceptions:
+      terminal_codes:
+        - InvalidParameterValueException
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)

--- a/generator.yaml
+++ b/generator.yaml
@@ -37,6 +37,9 @@ resources:
         GetFunction:
           input_fields:
             FunctionName: Name
+    exceptions:
+      terminal_codes:
+        - InvalidParameterValueException
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/lambda-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.18.4
+	github.com/aws-controllers-k8s/runtime v0.18.5
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/go-logr/logr v1.2.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.18.4 h1:iwLYNwhbuiWZrHPoulGj75oT+alE91wCNkF1FUELiAw=
-github.com/aws-controllers-k8s/runtime v0.18.4/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
+github.com/aws-controllers-k8s/runtime v0.18.5 h1:P8oMQagd45JQaloVQ+duuJzMw4ii8/IXYIgPN2EjU+8=
+github.com/aws-controllers-k8s/runtime v0.18.5/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/test/e2e/resources/function_package_type_image.yaml
+++ b/test/e2e/resources/function_package_type_image.yaml
@@ -1,0 +1,13 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Function
+metadata:
+  name: $FUNCTION_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $FUNCTION_NAME
+  code:
+    imageURI: $IMAGE_URL
+  role: $LAMBDA_ROLE
+  description: function created by ACK lambda-controller e2e tests
+  packageType: Image

--- a/test/e2e/resources/lambda_function/Dockerfile
+++ b/test/e2e/resources/lambda_function/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+COPY main.py main.py
+
+CMD [ "main.handler" ]

--- a/test/e2e/resources/lambda_function/Makefile
+++ b/test/e2e/resources/lambda_function/Makefile
@@ -1,0 +1,17 @@
+AWS_REGION ?= "us-west-2"
+ECR_REPOSITORY ?= ack-e2e-testing-lambda-controller
+IMAGE_TAG ?= v1
+
+AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query "Account" --output text)
+IMAGE_URL ?= $(AWS_ACCOUNT_ID).dkr.ecr.us-west-2.amazonaws.com/$(ECR_REPOSITORY):$(IMAGE_TAG)
+
+build-image:
+	docker build -t $(IMAGE_URL) .
+
+publish-image:
+	docker push $(IMAGE_URL)
+
+create-ecr-repository:
+	aws ecr create-repository --region $(AWS_REGION) --repository-name $(ECR_REPOSITORY) >/dev/null
+
+all: build-image publish-image


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1117

Description of changes:
Functions code signing config should only be called when a function is
created using an s3bucket and a key. Functions created using a container
image cannot get a code signing configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
