### PR TITLE
updating gitignore to be consistent with other controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 *.zip
+.DS_Store
+*.swp
+*~
+.idea
+/docs/site
+bin
+build
+go.local.sum


### PR DESCRIPTION
Issue #, if available:
N/A
Description of changes:
updating gitignore to be consistent with other projects, so non-project files do not end up in the repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>
