### PR TITLE
Add `Function` layers support

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-15T17:24:14Z"
-  build_hash: 50c64871bcaf88b9ee200eb8d6b8245fa8f675eb
-  go_version: go1.17.5
-  version: v0.18.4
-api_directory_checksum: a704674d4df0400198d5a11035a2099240bccf80
+  build_date: "2022-04-27T16:40:07Z"
+  build_hash: 141cb9db73f881228ea20e572de3ba9df19d5b6f
+  go_version: go1.18.1
+  version: v0.18.4-4-g141cb9d-dirty
+api_directory_checksum: 7c4e0f8971a8ab06389e98b21c00eddad87366f3
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: f04b298afa1fd7fd3980226d52412de9ca1523d4
+  file_checksum: c48a2acfc8da0b28ee9b81745b9af773d10c7f71
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/function.go
+++ b/apis/v1alpha1/function.go
@@ -54,6 +54,10 @@ type FunctionSpec struct {
 	// used to encrypt your function's environment variables. If it's not provided,
 	// Lambda uses a default service key.
 	KMSKeyARN *string `json:"kmsKeyARN,omitempty"`
+	// A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+	// to add to the function's execution environment. Specify each layer by its
+	// ARN, including the version.
+	Layers []*string `json:"layers,omitempty"`
 	// The amount of memory available to the function (https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html)
 	// at runtime. Increasing the function memory also increases its CPU allocation.
 	// The default value is 128 MB. The value can be any multiple of 1 MB.
@@ -139,7 +143,7 @@ type FunctionStatus struct {
 	LastUpdateStatusReasonCode *string `json:"lastUpdateStatusReasonCode,omitempty"`
 	// The function's layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 	// +kubebuilder:validation:Optional
-	Layers []*Layer `json:"layers,omitempty"`
+	LayerStatuses []*Layer `json:"layerStatuses,omitempty"`
 	// For Lambda@Edge functions, the ARN of the master function.
 	// +kubebuilder:validation:Optional
 	MasterARN *string `json:"masterARN,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -4,8 +4,6 @@ ignore:
     # Alias
     # CodeSigningConfig
     # EventSourceMapping
-  shape_names:
-    - LayerList
 resources:
   Function:
     fields:
@@ -19,6 +17,15 @@ resources:
       Code:
         compare:
           is_ignored: true
+      Layers:
+        set:
+          - method: Create
+            ignore: true
+      LayerStatuses:
+        is_read_only: true
+        from:
+          operation: GetFunction
+          path: Configuration.Layers
     renames:
       operations:
         CreateFunction:
@@ -37,6 +44,8 @@ resources:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/function/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/function/sdk_create_post_set_output.go.tpl
     update_operation:
       custom_method_name: customUpdateFunction
   Alias:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1486,6 +1486,17 @@ func (in *FunctionSpec) DeepCopyInto(out *FunctionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Layers != nil {
+		in, out := &in.Layers, &out.Layers
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	if in.MemorySize != nil {
 		in, out := &in.MemorySize, &out.MemorySize
 		*out = new(int64)
@@ -1617,8 +1628,8 @@ func (in *FunctionStatus) DeepCopyInto(out *FunctionStatus) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Layers != nil {
-		in, out := &in.Layers, &out.Layers
+	if in.LayerStatuses != nil {
+		in, out := &in.LayerStatuses, &out.LayerStatuses
 		*out = make([]*Layer, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {

--- a/config/crd/bases/lambda.services.k8s.aws_functions.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functions.yaml
@@ -122,6 +122,13 @@ spec:
                   (KMS) key that's used to encrypt your function's environment variables.
                   If it's not provided, Lambda uses a default service key.
                 type: string
+              layers:
+                description: A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+                  to add to the function's execution environment. Specify each layer
+                  by its ARN, including the version.
+                items:
+                  type: string
+                type: array
               memorySize:
                 description: The amount of memory available to the function (https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html)
                   at runtime. Increasing the function memory also increases its CPU
@@ -312,7 +319,7 @@ spec:
                 description: The reason code for the last update that was performed
                   on the function.
                 type: string
-              layers:
+              layerStatuses:
                 description: The function's layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
                 items:
                   description: An Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).

--- a/generator.yaml
+++ b/generator.yaml
@@ -4,8 +4,6 @@ ignore:
     # Alias
     # CodeSigningConfig
     # EventSourceMapping
-  shape_names:
-    - LayerList
 resources:
   Function:
     fields:
@@ -19,6 +17,15 @@ resources:
       Code:
         compare:
           is_ignored: true
+      Layers:
+        set:
+          - method: Create
+            ignore: true
+      LayerStatuses:
+        is_read_only: true
+        from:
+          operation: GetFunction
+          path: Configuration.Layers
     renames:
       operations:
         CreateFunction:
@@ -37,6 +44,8 @@ resources:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/function/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/function/sdk_create_post_set_output.go.tpl
     update_operation:
       custom_method_name: customUpdateFunction
   Alias:

--- a/helm/crds/lambda.services.k8s.aws_functions.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functions.yaml
@@ -122,6 +122,13 @@ spec:
                   (KMS) key that's used to encrypt your function's environment variables.
                   If it's not provided, Lambda uses a default service key.
                 type: string
+              layers:
+                description: A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+                  to add to the function's execution environment. Specify each layer
+                  by its ARN, including the version.
+                items:
+                  type: string
+                type: array
               memorySize:
                 description: The amount of memory available to the function (https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html)
                   at runtime. Increasing the function memory also increases its CPU
@@ -312,7 +319,7 @@ spec:
                 description: The reason code for the last update that was performed
                   on the function.
                 type: string
-              layers:
+              layerStatuses:
                 description: The function's layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
                 items:
                   description: An Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -115,6 +115,9 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyARN", a.ko.Spec.KMSKeyARN, b.ko.Spec.KMSKeyARN)
 		}
 	}
+	if !ackcompare.SliceStringPEqual(a.ko.Spec.Layers, b.ko.Spec.Layers) {
+		delta.Add("Spec.Layers", a.ko.Spec.Layers, b.ko.Spec.Layers)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MemorySize, b.ko.Spec.MemorySize) {
 		delta.Add("Spec.MemorySize", a.ko.Spec.MemorySize, b.ko.Spec.MemorySize)
 	} else if a.ko.Spec.MemorySize != nil && b.ko.Spec.MemorySize != nil {

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -242,7 +242,28 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Status.LastUpdateStatusReasonCode = nil
 	}
-
+	if resp.Configuration.Layers != nil {
+		f16 := []*svcapitypes.Layer{}
+		for _, f16iter := range resp.Configuration.Layers {
+			f16elem := &svcapitypes.Layer{}
+			if f16iter.Arn != nil {
+				f16elem.ARN = f16iter.Arn
+			}
+			if f16iter.CodeSize != nil {
+				f16elem.CodeSize = f16iter.CodeSize
+			}
+			if f16iter.SigningJobArn != nil {
+				f16elem.SigningJobARN = f16iter.SigningJobArn
+			}
+			if f16iter.SigningProfileVersionArn != nil {
+				f16elem.SigningProfileVersionARN = f16iter.SigningProfileVersionArn
+			}
+			f16 = append(f16, f16elem)
+		}
+		ko.Status.LayerStatuses = f16
+	} else {
+		ko.Status.LayerStatuses = nil
+	}
 	if resp.Configuration.MasterArn != nil {
 		ko.Status.MasterARN = resp.Configuration.MasterArn
 	} else {
@@ -549,28 +570,6 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.LastUpdateStatusReasonCode = nil
 	}
-	if resp.Layers != nil {
-		f16 := []*svcapitypes.Layer{}
-		for _, f16iter := range resp.Layers {
-			f16elem := &svcapitypes.Layer{}
-			if f16iter.Arn != nil {
-				f16elem.ARN = f16iter.Arn
-			}
-			if f16iter.CodeSize != nil {
-				f16elem.CodeSize = f16iter.CodeSize
-			}
-			if f16iter.SigningJobArn != nil {
-				f16elem.SigningJobARN = f16iter.SigningJobArn
-			}
-			if f16iter.SigningProfileVersionArn != nil {
-				f16elem.SigningProfileVersionARN = f16iter.SigningProfileVersionArn
-			}
-			f16 = append(f16, f16elem)
-		}
-		ko.Status.Layers = f16
-	} else {
-		ko.Status.Layers = nil
-	}
 	if resp.MasterArn != nil {
 		ko.Status.MasterARN = resp.MasterArn
 	} else {
@@ -671,6 +670,28 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if resp.Layers != nil {
+		f16 := []*svcapitypes.Layer{}
+		for _, f16iter := range resp.Layers {
+			f16elem := &svcapitypes.Layer{}
+			if f16iter.Arn != nil {
+				f16elem.ARN = f16iter.Arn
+			}
+			if f16iter.CodeSize != nil {
+				f16elem.CodeSize = f16iter.CodeSize
+			}
+			if f16iter.SigningJobArn != nil {
+				f16elem.SigningJobARN = f16iter.SigningJobArn
+			}
+			if f16iter.SigningProfileVersionArn != nil {
+				f16elem.SigningProfileVersionARN = f16iter.SigningProfileVersionArn
+			}
+			f16 = append(f16, f16elem)
+		}
+		ko.Status.LayerStatuses = f16
+	} else {
+		ko.Status.LayerStatuses = nil
+	}
 	return &resource{ko}, nil
 }
 
@@ -784,6 +805,15 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.KMSKeyARN != nil {
 		res.SetKMSKeyArn(*r.ko.Spec.KMSKeyARN)
 	}
+	if r.ko.Spec.Layers != nil {
+		f11 := []*string{}
+		for _, f11iter := range r.ko.Spec.Layers {
+			var f11elem string
+			f11elem = *f11iter
+			f11 = append(f11, &f11elem)
+		}
+		res.SetLayers(f11)
+	}
 	if r.ko.Spec.MemorySize != nil {
 		res.SetMemorySize(*r.ko.Spec.MemorySize)
 	}
@@ -800,45 +830,45 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetRuntime(*r.ko.Spec.Runtime)
 	}
 	if r.ko.Spec.Tags != nil {
-		f16 := map[string]*string{}
-		for f16key, f16valiter := range r.ko.Spec.Tags {
-			var f16val string
-			f16val = *f16valiter
-			f16[f16key] = &f16val
+		f17 := map[string]*string{}
+		for f17key, f17valiter := range r.ko.Spec.Tags {
+			var f17val string
+			f17val = *f17valiter
+			f17[f17key] = &f17val
 		}
-		res.SetTags(f16)
+		res.SetTags(f17)
 	}
 	if r.ko.Spec.Timeout != nil {
 		res.SetTimeout(*r.ko.Spec.Timeout)
 	}
 	if r.ko.Spec.TracingConfig != nil {
-		f18 := &svcsdk.TracingConfig{}
+		f19 := &svcsdk.TracingConfig{}
 		if r.ko.Spec.TracingConfig.Mode != nil {
-			f18.SetMode(*r.ko.Spec.TracingConfig.Mode)
+			f19.SetMode(*r.ko.Spec.TracingConfig.Mode)
 		}
-		res.SetTracingConfig(f18)
+		res.SetTracingConfig(f19)
 	}
 	if r.ko.Spec.VPCConfig != nil {
-		f19 := &svcsdk.VpcConfig{}
+		f20 := &svcsdk.VpcConfig{}
 		if r.ko.Spec.VPCConfig.SecurityGroupIDs != nil {
-			f19f0 := []*string{}
-			for _, f19f0iter := range r.ko.Spec.VPCConfig.SecurityGroupIDs {
-				var f19f0elem string
-				f19f0elem = *f19f0iter
-				f19f0 = append(f19f0, &f19f0elem)
+			f20f0 := []*string{}
+			for _, f20f0iter := range r.ko.Spec.VPCConfig.SecurityGroupIDs {
+				var f20f0elem string
+				f20f0elem = *f20f0iter
+				f20f0 = append(f20f0, &f20f0elem)
 			}
-			f19.SetSecurityGroupIds(f19f0)
+			f20.SetSecurityGroupIds(f20f0)
 		}
 		if r.ko.Spec.VPCConfig.SubnetIDs != nil {
-			f19f1 := []*string{}
-			for _, f19f1iter := range r.ko.Spec.VPCConfig.SubnetIDs {
-				var f19f1elem string
-				f19f1elem = *f19f1iter
-				f19f1 = append(f19f1, &f19f1elem)
+			f20f1 := []*string{}
+			for _, f20f1iter := range r.ko.Spec.VPCConfig.SubnetIDs {
+				var f20f1elem string
+				f20f1elem = *f20f1iter
+				f20f1 = append(f20f1, &f20f1elem)
 			}
-			f19.SetSubnetIds(f19f1)
+			f20.SetSubnetIds(f20f1)
 		}
-		res.SetVpcConfig(f19)
+		res.SetVpcConfig(f20)
 	}
 
 	return res, nil

--- a/templates/hooks/function/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,22 @@
+	if resp.Layers != nil {
+		f16 := []*svcapitypes.Layer{}
+		for _, f16iter := range resp.Layers {
+			f16elem := &svcapitypes.Layer{}
+			if f16iter.Arn != nil {
+				f16elem.ARN = f16iter.Arn
+			}
+			if f16iter.CodeSize != nil {
+				f16elem.CodeSize = f16iter.CodeSize
+			}
+			if f16iter.SigningJobArn != nil {
+				f16elem.SigningJobARN = f16iter.SigningJobArn
+			}
+			if f16iter.SigningProfileVersionArn != nil {
+				f16elem.SigningProfileVersionARN = f16iter.SigningProfileVersionArn
+			}
+			f16 = append(f16, f16elem)
+		}
+		ko.Status.LayerStatuses = f16
+	} else {
+		ko.Status.LayerStatuses = nil
+	}

--- a/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
@@ -137,7 +137,28 @@
 	} else {
 		ko.Status.LastUpdateStatusReasonCode = nil
 	}
-
+	if resp.Configuration.Layers != nil {
+		f16 := []*svcapitypes.Layer{}
+		for _, f16iter := range resp.Configuration.Layers {
+			f16elem := &svcapitypes.Layer{}
+			if f16iter.Arn != nil {
+				f16elem.ARN = f16iter.Arn
+			}
+			if f16iter.CodeSize != nil {
+				f16elem.CodeSize = f16iter.CodeSize
+			}
+			if f16iter.SigningJobArn != nil {
+				f16elem.SigningJobARN = f16iter.SigningJobArn
+			}
+			if f16iter.SigningProfileVersionArn != nil {
+				f16elem.SigningProfileVersionARN = f16iter.SigningProfileVersionArn
+			}
+			f16 = append(f16, f16elem)
+		}
+		ko.Status.LayerStatuses = f16
+	} else {
+		ko.Status.LayerStatuses = nil
+	}
 	if resp.Configuration.MasterArn != nil {
 		ko.Status.MasterARN = resp.Configuration.MasterArn
 	} else {


### PR DESCRIPTION
Part of https://github.com/aws-controllers-k8s/community/issues/1062

Description of changes:
- Bring back the `Spec.Layers` field
- Add a new field called `LayersReference` in status to store the layers
references returned by the Lambda control plane
- Add hooks to properly set `Status.LayersReference` after a create and
a read call

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
