### PR TITLE
Refactor controller end-to-end tests

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -16,32 +16,29 @@ for them.
 """
 
 from dataclasses import dataclass
-from acktest.resources import read_bootstrap_config
+
+from acktest.bootstrapping import Resources
+from acktest.bootstrapping.s3 import Bucket
+from acktest.bootstrapping.dynamodb import Table
+from acktest.bootstrapping.signer import SigningProfile
+from acktest.bootstrapping.sqs import Queue
+from acktest.bootstrapping.iam import Role
+
 from e2e import bootstrap_directory
 
 @dataclass
-class TestBootstrapResources:
-    FunctionsBucketName: str
-    LambdaFunctionFilePath: str
-    LambdaFunctionFileZip: str
-    LambdaBasicRoleName: str
-    LambdaBasicRoleARN: str
-    LambdaESMRoleName: str
-    LambdaESMRoleARN: str
-    SigningProfileVersionArn: str
-    SQSQueueARN: str
-    SQSQueueURL: str
-    DynamoDBTableName: str
-    DynamoDBTableARN: str
-    BasicExecutionRoleARNs: list
-    ESMExecutionRoleARNs: list
+class BootstrapResources(Resources):
+    FunctionsBucket: Bucket
+    SigningProfile: SigningProfile
+    BasicRole: Role
+    ESMRole: Role
+    ESMTable: Table
+    ESMQueue: Queue
 
 _bootstrap_resources = None
 
-def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.pkl") -> BootstrapResources:
     global _bootstrap_resources
     if _bootstrap_resources is None:
-        _bootstrap_resources = TestBootstrapResources(
-            **read_bootstrap_config(bootstrap_directory, bootstrap_file_name=bootstrap_file_name),
-        )
+        _bootstrap_resources = BootstrapResources.deserialize(bootstrap_directory, bootstrap_file_name=bootstrap_file_name)
     return _bootstrap_resources

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -11,9 +11,10 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import os
 import pytest
+import boto3
 
+from acktest.aws.identity import get_region
 from acktest import k8s
 
 
@@ -44,3 +45,7 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope='class')
 def k8s_client():
     return k8s._get_k8s_api_client()
+
+@pytest.fixture(scope='module')
+def lambda_client():
+    return boto3.client('lambda', region_name=get_region())

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@3d5e98f5960ac2ea8360c212141c4ec89cfcb668
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@58ffb067d7c400ffbd0d470e975056efdc9e4965

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -16,21 +16,18 @@
 import os
 import boto3
 import logging
-from time import sleep
 from zipfile import ZipFile
-import random
-import string
 
-from acktest import resources
-from acktest.aws.identity import get_region, get_account_id
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import TestBootstrapResources
+from e2e.bootstrap_resources import BootstrapResources
 from botocore.exceptions import ClientError
 
-RAND_TEST_SUFFIX = (''.join(random.choice(string.ascii_lowercase) for _ in range(6)))
-
-LAMBDA_BASIC_IAM_ROLE_NAME = 'ack-lambda-function-role-basic-' + RAND_TEST_SUFFIX
-LAMBDA_ESM_IAM_ROLE_NAME = 'ack-lambda-function-role-esm-' + RAND_TEST_SUFFIX
+from acktest.bootstrapping import Resources, BootstrapFailureException
+from acktest.bootstrapping.s3 import Bucket
+from acktest.bootstrapping.dynamodb import Table
+from acktest.bootstrapping.signer import SigningProfile
+from acktest.bootstrapping.sqs import Queue
+from acktest.bootstrapping.iam import Role
 
 LAMBDA_IAM_ROLE_POLICY = '{"Version": "2012-10-17","Statement": [{ "Effect": "Allow", "Principal": {"Service": '\
                                 '"lambda.amazonaws.com"}, "Action": "sts:AssumeRole"}]} '
@@ -38,103 +35,15 @@ LAMBDA_BASIC_EXECUTION_ARN = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasi
 LAMBDA_DYNAMODB_EXECUTION_ROLE = 'arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole'
 LAMBDA_SQS_QUEUE_EXECUTION_ROLE = 'arn:aws:iam::aws:policy/AmazonSQSFullAccess'
 
-BASIC_ROLES = [ LAMBDA_BASIC_EXECUTION_ARN ]
-ESM_ROLES = [ LAMBDA_BASIC_EXECUTION_ARN, LAMBDA_DYNAMODB_EXECUTION_ROLE, LAMBDA_SQS_QUEUE_EXECUTION_ROLE ]
-
-FUNCTIONS_BUCKET_NAME = "ack-lambda-function-s3-bucket-" + RAND_TEST_SUFFIX
+BASIC_ROLE_POLICIES = [ LAMBDA_BASIC_EXECUTION_ARN ]
+ESM_ROLE_POLICIES = [ LAMBDA_BASIC_EXECUTION_ARN, LAMBDA_DYNAMODB_EXECUTION_ROLE, LAMBDA_SQS_QUEUE_EXECUTION_ROLE ]
 
 LAMBDA_FUNCTION_FILE = "main.py"
 LAMBDA_FUNCTION_FILE_ZIP = "main.zip"
 LAMBDA_FUNCTION_FILE_PATH = f"./resources/lambda_function/{LAMBDA_FUNCTION_FILE}"
 LAMBDA_FUNCTION_FILE_PATH_ZIP = f"./resources/lambda_function/{LAMBDA_FUNCTION_FILE_ZIP}"
 
-AWS_SIGNING_PROFILE_NAME = "ack_testing_lambda_signing_profile"
 AWS_SIGNING_PLATFORM_ID = "AWSLambda-SHA384-ECDSA"
-
-SQS_QUEUE_NAME = "ack-lambda-sqs-queue-" + RAND_TEST_SUFFIX
-
-DYNAMODB_TABLE_NAME = "ack-lambda-ddb-table-" + RAND_TEST_SUFFIX
-
-def service_bootstrap() -> dict:
-    logging.getLogger().setLevel(logging.INFO)
-    lambda_esm_role_arn = create_lambda_function_esm_role(LAMBDA_ESM_IAM_ROLE_NAME)
-    lambda_basic_role_arn = create_lambda_function_basic_role(LAMBDA_BASIC_IAM_ROLE_NAME)
-    create_bucket(FUNCTIONS_BUCKET_NAME)
-    zip_function_file(LAMBDA_FUNCTION_FILE_PATH, LAMBDA_FUNCTION_FILE_PATH_ZIP)
-    upload_function_to_bucket(LAMBDA_FUNCTION_FILE_PATH_ZIP, FUNCTIONS_BUCKET_NAME)
-    signing_profile_version_arn = ensure_signing_profile(AWS_SIGNING_PROFILE_NAME, AWS_SIGNING_PLATFORM_ID)
-    sqs_queue_arn, sqs_queue_url = create_sqs_queue(SQS_QUEUE_NAME)
-    dynamodb_table_stream_arn = create_dynamodb_table(DYNAMODB_TABLE_NAME)
-
-    return TestBootstrapResources(
-        FUNCTIONS_BUCKET_NAME,
-        LAMBDA_FUNCTION_FILE_PATH,
-        LAMBDA_FUNCTION_FILE_ZIP,
-        LAMBDA_BASIC_IAM_ROLE_NAME,
-        lambda_basic_role_arn,
-        LAMBDA_ESM_IAM_ROLE_NAME,
-        lambda_esm_role_arn,
-        signing_profile_version_arn,
-        sqs_queue_arn,
-        sqs_queue_url,
-        DYNAMODB_TABLE_NAME,
-        dynamodb_table_stream_arn,
-        BASIC_ROLES,
-        ESM_ROLES,
-    ).__dict__
-
-
-
-def create_role_with_policies(iam_role_name: str, policies: list) -> str:
-    region = get_region()
-    iam_client = boto3.client("iam", region_name=region)
-
-    logging.debug(f"Creating iam role {iam_role_name}")
-    try:
-        iam_client.get_role(RoleName=iam_role_name)
-        raise RuntimeError(f"Expected {iam_role_name} role to not exist."
-                           f" Did previous test cleanup successfully?")
-    except iam_client.exceptions.NoSuchEntityException:
-        pass
-
-    resp = iam_client.create_role(
-        RoleName=iam_role_name,
-        AssumeRolePolicyDocument=LAMBDA_IAM_ROLE_POLICY
-    )
-
-    for policyARN in policies:
-        iam_client.attach_role_policy(RoleName=iam_role_name, PolicyArn=policyARN)
-
-    logging.info(f"Created role {iam_role_name}")
-    return resp['Role']['Arn']
-
-
-def create_lambda_function_basic_role(iam_role_name: str) -> str:
-    return create_role_with_policies(
-        iam_role_name,
-        BASIC_ROLES,
-    )
-
-def create_lambda_function_esm_role(iam_role_name: str) -> str:
-    return create_role_with_policies(
-        iam_role_name,
-        ESM_ROLES,
-    )
-
-def create_bucket(bucket_name: str):
-    region = get_region()
-    s3_client = boto3.resource('s3')
-    logging.debug(f"Creating s3 data bucket {bucket_name}")
-    try:
-        s3_client.create_bucket(
-            Bucket=bucket_name,
-            CreateBucketConfiguration={"LocationConstraint": region}
-        )
-    except s3_client.exceptions.BucketAlreadyExists:
-        raise RuntimeError(f"Expected {bucket_name} bucket to not exist."
-                           f" Did previous test cleanup successfully?")
-
-    logging.info(f"Created bucket {bucket_name}")
 
 def zip_function_file(src: str, dst: str):
     with ZipFile(dst, 'w') as zipf:
@@ -155,73 +64,74 @@ def upload_function_to_bucket(file_path: str, bucket_name: str):
 
     logging.info(f"Uploaded {file_path} to bucket {bucket_name}")
 
-def ensure_signing_profile(signing_profile_name: str, platform_id: str) -> str:
-    region = get_region()
-    signer_client = boto3.client("signer", region_name=region)
+def service_bootstrap() -> Resources:
+    logging.getLogger().setLevel(logging.INFO)
+    resources = BootstrapResources(
+        FunctionsBucket=Bucket(
+            "ack-lambda-controller-tests",
+        ),
+        SigningProfile=SigningProfile(
+            "ack_testing_signer",
+            signing_platform_id=AWS_SIGNING_PLATFORM_ID,
+        ),
+        BasicRole=Role(
+            "ack-lambda-controller-basic-role",
+            principal_service="lambda.amazonaws.com",
+            managed_policies=BASIC_ROLE_POLICIES,
+        ),
+        ESMRole=Role(
+            "ack-lambda-controller-esm-role",
+            principal_service="lambda.amazonaws.com",
+            managed_policies=ESM_ROLE_POLICIES,
+        ),
+        ESMTable=Table(
+            "ack-lambda-controller-table",
+            attribute_definitions=[
+                {
+                    'AttributeName': 'id',
+                    'AttributeType': 'N'
+                },
+                {
+                    'AttributeName': 'createdAt',
+                    'AttributeType': 'S'
+                },
+            ],
+            key_schema=[
+                {
+                    'AttributeName': 'id',
+                    'KeyType': 'HASH'
+                },
+                {
+                    'AttributeName': 'createdAt',
+                    'KeyType': 'RANGE'
+                }
+            ],
+            stream_specification={
+                'StreamEnabled': True,
+                'StreamViewType': 'NEW_IMAGE'
+            },
+            provisioned_throughput={
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5
+            },
+        ),
+        ESMQueue=Queue(
+            "ack-lambda-controller-queue"
+        ),
+    )
 
-    # Signing profiles cannot be deleted. We just reuse the same signing profile
-    # for ACK lambda controller e2e tests.
     try:
-        resp = signer_client.get_signing_profile(
-            profileName=signing_profile_name,
+        resources.bootstrap()
+        zip_function_file(LAMBDA_FUNCTION_FILE_PATH, LAMBDA_FUNCTION_FILE_PATH_ZIP)
+        upload_function_to_bucket(
+            LAMBDA_FUNCTION_FILE_PATH_ZIP,
+            resources.FunctionsBucket.name,
         )
-        return resp['profileVersionArn']
-    except:
-        resp = signer_client.put_signing_profile(
-            profileName=signing_profile_name,
-            platformId=platform_id,
-        )
-        logging.info(f"Created signing profile {signing_profile_name}")
-        return resp['profileVersionArn']
-
-def create_sqs_queue(queue_name: str) -> str:
-    region = get_region()
-    sqs_client = boto3.resource('sqs', region_name=region)
-    logging.debug(f"Creating SQS queue {queue_name}")
-    resp = sqs_client.create_queue(
-        QueueName=queue_name,
-    )
-    logging.info(f"Created SQS queue {queue_name}")
-    return resp.attributes['QueueArn'], resp.url
-
-def create_dynamodb_table(table_name: str) -> str:
-    region = get_region()
-    dynamodb_client = boto3.resource('dynamodb', region_name=region)
-    resp = dynamodb_client.create_table(
-        TableName=table_name,
-        KeySchema=[
-            {
-                'AttributeName': 'id',
-                'KeyType': 'HASH'
-            },
-            {
-                'AttributeName': 'createdAt',
-                'KeyType': 'RANGE'
-            }
-        ],
-        AttributeDefinitions=[
-            {
-                'AttributeName': 'id',
-                'AttributeType': 'N'
-            },
-            {
-                'AttributeName': 'createdAt',
-                'AttributeType': 'S'
-            },
-        ],
-        ProvisionedThroughput={
-            'ReadCapacityUnits': 5,
-            'WriteCapacityUnits': 5
-        },
-        StreamSpecification={
-            'StreamEnabled': True,
-            'StreamViewType': 'NEW_IMAGE'
-        }
-    )
-    logging.info(f"Created Dynamodb table {table_name}")
-    return resp.latest_stream_arn
+    except BootstrapFailureException as ex:
+        exit(254)
+    return resources
 
 if __name__ == "__main__":
     config = service_bootstrap()
     # Write config to current directory by default
-    resources.write_bootstrap_config(config, bootstrap_directory)
+    config.serialize(bootstrap_directory)

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -10,86 +10,20 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-"""Cleans up the resources created by Lambda bootstrapping process.
+
+"""Cleans up the resources created by the bootstrapping process.
 """
 
-import boto3
 import logging
 
-from acktest import resources
-from acktest.aws.identity import get_region
-
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import TestBootstrapResources
+from acktest.bootstrapping import Resources
 
-def service_cleanup(config: dict):
+def service_cleanup():
     logging.getLogger().setLevel(logging.INFO)
-    resources = TestBootstrapResources(
-        **config
-    )
 
-    try:
-        detach_policies_and_delete_role(resources.LambdaBasicRoleName, resources.BasicExecutionRoleARNs)
-    except:
-        logging.exception(f"Unable to delete basic role {resources.LambdaBasicRoleARN}")
-
-    try:
-        detach_policies_and_delete_role(resources.LambdaESMRoleName, resources.ESMExecutionRoleARNs)
-    except:
-        logging.exception(f"Unable to delete esm role {resources.LambdaESMRoleARN}")
-
-    try:
-        clean_up_and_delete_bucket(resources.FunctionsBucketName)
-    except:
-        logging.exception(f"Unable to delete bucket {resources.FunctionsBucketName}")
-
-    try:
-        delete_sqs_queue(resources.SQSQueueURL)
-    except:
-        logging.exception(f"Unable to delete queue {resources.SQSQueueURL}")
-
-    try:
-        delete_dynamodb_table(resources.DynamoDBTableName)
-    except:
-        logging.exception(f"Unable to delete table {resources.DynamoDBTableName}")
-
-def detach_policies_and_delete_role(iam_role_name: str, iam_policy_arns: list):
-    region = get_region()
-    iam_client = boto3.client("iam", region_name=region)
-    for iam_policy_arn in iam_policy_arns:
-        iam_client.detach_role_policy(RoleName=iam_role_name, PolicyArn=iam_policy_arn)
-    iam_client.delete_role(RoleName=iam_role_name)
-    logging.info(f"Deleted role {iam_role_name}")
-
-def clean_up_and_delete_bucket(bucket_name: str):
-    region = get_region()
-    s3_client = boto3.client("s3", region_name=region)
-
-    resp = s3_client.list_objects(Bucket=bucket_name)
-    for object in resp['Contents']:
-        s3_client.delete_object(Bucket=bucket_name, Key=object['Key'])
-
-    s3_client.delete_bucket(
-        Bucket=bucket_name,
-    )
-    logging.info(f"Deleted bucket {bucket_name}")
-
-def delete_sqs_queue(queue_url: str) -> str:
-    region = get_region()
-    sqs_client = boto3.client('sqs', region_name=region)
-    sqs_client.delete_queue(
-        QueueUrl=queue_url,
-    )
-    logging.info(f"Deleted SQS queue {queue_url}")
-
-def delete_dynamodb_table(table_name: str) -> str:
-    region = get_region()
-    ddb_client = boto3.client('dynamodb', region_name=region)
-    ddb_client.delete_table(
-        TableName=table_name,
-    )
-    logging.info(f"Deleted DynamoDB table {table_name}")
+    resources = Resources.deserialize(bootstrap_directory)
+    resources.cleanup()
 
 if __name__ == "__main__":   
-    bootstrap_config = resources.read_bootstrap_config(bootstrap_directory)
-    service_cleanup(bootstrap_config)
+    service_cleanup() 

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Helper functions for Lambda e2e tests
+"""
+
+import logging
+
+class LambdaValidator:
+    def __init__(self, lambda_client):
+        self.lambda_client = lambda_client
+
+    def get_function(self, function_name: str) -> dict:
+        try:
+            resp = self.lambda_client.get_function(
+                FunctionName=function_name
+            )
+            return resp
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def get_function_concurrency(self, function_name: str) -> int:
+        try:
+            resp = self.lambda_client.get_function_concurrency(
+                FunctionName=function_name
+            )
+            return resp['ReservedConcurrentExecutions']
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def get_function_code_signing_config(self, function_name: str) -> int:
+        try:
+            resp = self.lambda_client.get_function_code_signing_config(
+                FunctionName=function_name
+            )
+            return resp['CodeSigningConfigArn']
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def function_exists(self, function_name) -> bool:
+        return self.get_function(function_name) is not None
+
+    def get_event_source_mapping(self, esm_uuid: str) -> dict:
+        try:
+            resp = self.lambda_client.get_event_source_mapping(
+                UUID=esm_uuid,
+            )
+            return resp
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def event_source_mapping_exists(self, esm_uuid: str) -> bool:
+        return self.get_event_source_mapping(esm_uuid) is not None
+
+    def get_code_signing_config(self, code_signing_config_arn: str) -> dict:
+        try:
+            resp = self.lambda_client.get_code_signing_config(
+                CodeSigningConfigArn=code_signing_config_arn,
+            )
+            return resp["CodeSigningConfig"]
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def code_signing_config_exists(self, code_signing_config_arn: str) -> bool:
+        return self.get_code_signing_config(code_signing_config_arn) is not None
+
+    def get_alias(self, alias_name: str, function_name: str) -> dict:
+        try:
+            resp = self.lambda_client.get_alias(
+                Name=alias_name,
+                FunctionName=function_name
+            )
+            return resp
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def alias_exists(self, alias_name: str, function_name: str) -> bool:
+        return self.get_alias(alias_name, function_name) is not None


### PR DESCRIPTION
Description of changes:

This patch refactors the python end-to-end tests used to test the
lambda-controller and fixes multiple tests and boosttrapping errors
observed in recent PRs.

Mainly this patch rewrites the bootstrapping logic and uses the latest
bootstrappable resources (IAM Role, SQS Queue, DynamoDB Table, and
Signer SigningProfile) introduced in `acktest` library. Also, this patch 
moves the testing asserting logic into a `LambdaValidator` class.

Unblocks #37

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
