### PR TITLE
Add ECR and S3 ReadOnly access to the recommended policy

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow", 
+            "Action": [
+                "lambda:*",
+                "s3:Get*",
+                "ecr:Get*",
+                "iam:PassRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/recommended-policy-arn
+++ b/config/iam/recommended-policy-arn
@@ -1,1 +1,0 @@
-arn:aws:iam::aws:policy/AWSLambda_FullAccess


### PR DESCRIPTION
Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

Add ECR and S3 ReadOnly access to the recommended policy for
lambda-controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
