### PR TITLE
Add `docker-ecr-auth` rule to testing Makefile

### DIFF
--- a/test/e2e/resources/lambda_function/Makefile
+++ b/test/e2e/resources/lambda_function/Makefile
@@ -14,4 +14,9 @@ publish-image:
 create-ecr-repository:
 	aws ecr create-repository --region $(AWS_REGION) --repository-name $(ECR_REPOSITORY) >/dev/null
 
+docker-ecr-auth:
+	aws ecr get-login-password --region us-west-2 | \
+		docker login --username AWS --password-stdin\
+		$(AWS_ACCOUNT_ID).dkr.ecr.us-west-2.amazonaws.com
+
 all: build-image publish-image


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add `docker-ecr-auth` rule to testing Makefile

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
