### PR TITLE
Adding `service-team` members in the team controller alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,4 +8,6 @@ aliases:
     - RedbackThomson
     - vijtrip2
   # TODO: Add your team members to your team controller alias
-  service-team: []
+  service-team: 
+    - Vandita2020
+    - valerena


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adding `service-team` members in the team controller alias, inside the `OWNERS_ALIASES` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
