### PR TITLE
Support `Function` references in `Alias` resource

### DIFF
--- a/apis/v1alpha1/alias.go
+++ b/apis/v1alpha1/alias.go
@@ -38,8 +38,8 @@ type AliasSpec struct {
 	//
 	// The length constraint applies only to the full ARN. If you specify only the
 	// function name, it is limited to 64 characters in length.
-	// +kubebuilder:validation:Required
-	FunctionName *string `json:"functionName"`
+	FunctionName *string                                  `json:"functionName,omitempty"`
+	FunctionRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"functionRef,omitempty"`
 	// The function version that the alias invokes.
 	// +kubebuilder:validation:Required
 	FunctionVersion *string `json:"functionVersion"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -62,6 +62,9 @@ resources:
         is_primary_key: true
       FunctionName:
         is_required: true
+        references:
+          resource: Function
+          path: Spec.Name 
       FunctionVersion:
         is_required: true
     tags:

--- a/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: aliases.lambda.services.k8s.aws
 spec:
@@ -40,11 +39,24 @@ spec:
                 type: string
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
-                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  * Function name - MyFunction. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n * Partial ARN - 123456789012:function:MyFunction. \n The length
                   constraint applies only to the full ARN. If you specify only the
                   function name, it is limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               functionVersion:
                 description: The function version that the alias invokes.
                 type: string
@@ -61,7 +73,6 @@ spec:
                     type: object
                 type: object
             required:
-            - functionName
             - functionVersion
             - name
             type: object
@@ -139,9 +150,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/generator.yaml
+++ b/generator.yaml
@@ -62,6 +62,9 @@ resources:
         is_primary_key: true
       FunctionName:
         is_required: true
+        references:
+          resource: Function
+          path: Spec.Name 
       FunctionVersion:
         is_required: true
     tags:

--- a/helm/crds/lambda.services.k8s.aws_aliases.yaml
+++ b/helm/crds/lambda.services.k8s.aws_aliases.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: aliases.lambda.services.k8s.aws
 spec:
@@ -40,11 +39,24 @@ spec:
                 type: string
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
-                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  * Function name - MyFunction. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n * Partial ARN - 123456789012:function:MyFunction. \n The length
                   constraint applies only to the full ARN. If you specify only the
                   function name, it is limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               functionVersion:
                 description: The function version that the alias invokes.
                 type: string
@@ -61,7 +73,6 @@ spec:
                     type: object
                 type: object
             required:
-            - functionName
             - functionVersion
             - name
             type: object
@@ -139,9 +150,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/resource/alias/delta.go
+++ b/pkg/resource/alias/delta.go
@@ -55,6 +55,9 @@ func newResourceDelta(
 			delta.Add("Spec.FunctionName", a.ko.Spec.FunctionName, b.ko.Spec.FunctionName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef) {
+		delta.Add("Spec.FunctionRef", a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FunctionVersion, b.ko.Spec.FunctionVersion) {
 		delta.Add("Spec.FunctionVersion", a.ko.Spec.FunctionVersion, b.ko.Spec.FunctionVersion)
 	} else if a.ko.Spec.FunctionVersion != nil && b.ko.Spec.FunctionVersion != nil {

--- a/test/e2e/resources/alias-ref.yaml
+++ b/test/e2e/resources/alias-ref.yaml
@@ -1,0 +1,13 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Alias
+metadata:
+  name: $ALIAS_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $ALIAS_NAME
+  functionRef:
+    from:
+      name: $FUNCTION_REF_NAME
+  functionVersion: $FUNCTION_VERSION
+  description: alias created by ACK lambda-controller e2e tests


### PR DESCRIPTION
Issue #, if available: 

Description of changes:
Adding functionality to the lambda controller to be able to reference a `Function` from an `Alias` resource using resource references.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
