### PR TITLE
Support `Function` references in `FunctionUrlConfig` resource

### DIFF
--- a/apis/v1alpha1/function_url_config.go
+++ b/apis/v1alpha1/function_url_config.go
@@ -45,8 +45,8 @@ type FunctionURLConfigSpec struct {
 	//
 	// The length constraint applies only to the full ARN. If you specify only the
 	// function name, it is limited to 64 characters in length.
-	// +kubebuilder:validation:Required
-	FunctionName *string `json:"functionName"`
+	FunctionName *string                                  `json:"functionName,omitempty"`
+	FunctionRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"functionRef,omitempty"`
 	// The alias name.
 	Qualifier *string `json:"qualifier,omitempty"`
 }

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -93,4 +93,7 @@ resources:
       ignore: true
     fields:
       FunctionName:
+        references:
+          resource: Function
+          path: Spec.Name
         is_primary_key: true

--- a/config/crd/bases/lambda.services.k8s.aws_functionurlconfigs.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functionurlconfigs.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: functionurlconfigs.lambda.services.k8s.aws
 spec:
@@ -72,17 +71,29 @@ spec:
                 type: object
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - my-function. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function.
-                  \n    * Partial ARN - 123456789012:function:my-function. \n The
-                  length constraint applies only to the full ARN. If you specify only
-                  the function name, it is limited to 64 characters in length."
+                  * Function name - my-function. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function.
+                  \n * Partial ARN - 123456789012:function:my-function. \n The length
+                  constraint applies only to the full ARN. If you specify only the
+                  function name, it is limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               qualifier:
                 description: The alias name.
                 type: string
             required:
             - authType
-            - functionName
             type: object
           status:
             description: FunctionURLConfigStatus defines the observed state of FunctionURLConfig
@@ -164,9 +175,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/generator.yaml
+++ b/generator.yaml
@@ -93,4 +93,7 @@ resources:
       ignore: true
     fields:
       FunctionName:
+        references:
+          resource: Function
+          path: Spec.Name
         is_primary_key: true

--- a/helm/crds/lambda.services.k8s.aws_functionurlconfigs.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functionurlconfigs.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: functionurlconfigs.lambda.services.k8s.aws
 spec:
@@ -72,17 +71,29 @@ spec:
                 type: object
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - my-function. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function.
-                  \n    * Partial ARN - 123456789012:function:my-function. \n The
-                  length constraint applies only to the full ARN. If you specify only
-                  the function name, it is limited to 64 characters in length."
+                  * Function name - my-function. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function.
+                  \n * Partial ARN - 123456789012:function:my-function. \n The length
+                  constraint applies only to the full ARN. If you specify only the
+                  function name, it is limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               qualifier:
                 description: The alias name.
                 type: string
             required:
             - authType
-            - functionName
             type: object
           status:
             description: FunctionURLConfigStatus defines the observed state of FunctionURLConfig
@@ -164,9 +175,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/resource/function_url_config/delta.go
+++ b/pkg/resource/function_url_config/delta.go
@@ -85,6 +85,9 @@ func newResourceDelta(
 			delta.Add("Spec.FunctionName", a.ko.Spec.FunctionName, b.ko.Spec.FunctionName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef) {
+		delta.Add("Spec.FunctionRef", a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Qualifier, b.ko.Spec.Qualifier) {
 		delta.Add("Spec.Qualifier", a.ko.Spec.Qualifier, b.ko.Spec.Qualifier)
 	} else if a.ko.Spec.Qualifier != nil && b.ko.Spec.Qualifier != nil {

--- a/pkg/resource/function_url_config/references.go
+++ b/pkg/resource/function_url_config/references.go
@@ -17,8 +17,15 @@ package function_url_config
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/lambda-controller/apis/v1alpha1"
@@ -36,17 +43,95 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForFunctionName(ctx, apiReader, namespace, ko)
+	}
+
+	// If there was an error while resolving any reference, reset all the
+	// resolved values so that they do not get persisted inside etcd
+	if err != nil {
+		ko = rm.concreteResource(res).ko.DeepCopy()
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.FunctionURLConfig) error {
+	if ko.Spec.FunctionRef != nil && ko.Spec.FunctionName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("FunctionName", "FunctionRef")
+	}
+	if ko.Spec.FunctionRef == nil && ko.Spec.FunctionName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionName", "FunctionRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.FunctionURLConfig) bool {
-	return false
+	return false || (ko.Spec.FunctionRef != nil)
+}
+
+// resolveReferenceForFunctionName reads the resource referenced
+// from FunctionRef field and sets the FunctionName
+// from referenced resource
+func resolveReferenceForFunctionName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.FunctionURLConfig,
+) error {
+	if ko.Spec.FunctionRef != nil &&
+		ko.Spec.FunctionRef.From != nil {
+		arr := ko.Spec.FunctionRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.Function{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Function",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"Function",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Function",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.FunctionName = &referencedValue
+	}
+	return nil
 }

--- a/test/e2e/resources/function_url_config_ref.yaml
+++ b/test/e2e/resources/function_url_config_ref.yaml
@@ -1,0 +1,12 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: FunctionURLConfig
+metadata:
+  name: $FUNCTION_URL_CONFIG_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $FUNCTION_URL_CONFIG_NAME
+  functionRef:
+    from:
+      name: $FUNCTION_REF_NAME
+  authType: $AUTH_TYPE


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adding functionality to the lambda controller to be able to reference a Function from a FunctionUrlConfig resource using resource references.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
