### PR TITLE
Initialise `spec.Code` before setting the imageURI

### DIFF
--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -104,6 +104,12 @@ func (rm *resourceManager) sdkFind(
 		// We need to keep the desired .Code s3Bucket s3Key and s3ObjectVersion
 		// part of the function's spec. So instead of setting Spec.Code to nil
 		// we only set ImageURI
+		//
+		// When adopting a Function resource, Spec.Code field should be manually
+		// initialised before injecting ImageURI.
+		if ko.Spec.Code == nil {
+			ko.Spec.Code = &svcapitypes.FunctionCode{}
+		}
 		if resp.Code.ImageUri != nil {
 			ko.Spec.Code.ImageURI = resp.Code.ImageUri
 		}

--- a/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
@@ -1,7 +1,13 @@
 	if resp.Code != nil {
-		// We need to keep the desired .Code s3Bucket s3Key and s3ObjectVersion 
+		// We need to keep the desired .Code s3Bucket s3Key and s3ObjectVersion
 		// part of the function's spec. So instead of setting Spec.Code to nil
 		// we only set ImageURI
+		//
+		// When adopting a Function resource, Spec.Code field should be manually
+		// initialised before injecting ImageURI.
+		if ko.Spec.Code == nil {
+			ko.Spec.Code = &svcapitypes.FunctionCode{}
+		}
 		if resp.Code.ImageUri != nil {
 			ko.Spec.Code.ImageURI = resp.Code.ImageUri
 		}


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1480

The runtime panics observed in issue 1480 were mainly caused by the
`sdk_read_one` hook we use for `Function` resource. The hook didn't
correctly initialise `spec.Code`.

This patch fixes the initialization to avoid nil pointer panics when
adopting function resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
