### PR TITLE
Fix the `zz_generated.deepcopy` file

### DIFF
--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -227,6 +227,11 @@ func (in *AliasSpec) DeepCopyInto(out *AliasSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FunctionRef != nil {
+		in, out := &in.FunctionRef, &out.FunctionRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FunctionVersion != nil {
 		in, out := &in.FunctionVersion, &out.FunctionVersion
 		*out = new(string)
@@ -1922,6 +1927,11 @@ func (in *FunctionURLConfigSpec) DeepCopyInto(out *FunctionURLConfigSpec) {
 		in, out := &in.FunctionName, &out.FunctionName
 		*out = new(string)
 		**out = **in
+	}
+	if in.FunctionRef != nil {
+		in, out := &in.FunctionRef, &out.FunctionRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Qualifier != nil {
 		in, out := &in.Qualifier, &out.Qualifier


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adding the `zz_generated.deepcopy` file for FunctionUrlConfig resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
