### PR TITLE
Support `function` reference in `EventSourceMappingSQS` resource

### DIFF
--- a/apis/v1alpha1/event_source_mapping.go
+++ b/apis/v1alpha1/event_source_mapping.go
@@ -79,8 +79,8 @@ type EventSourceMappingSpec struct {
 	//
 	// The length constraint applies only to the full ARN. If you specify only the
 	// function name, it's limited to 64 characters in length.
-	// +kubebuilder:validation:Required
-	FunctionName *string `json:"functionName"`
+	FunctionName *string                                  `json:"functionName,omitempty"`
+	FunctionRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"functionRef,omitempty"`
 	// (Streams and Amazon SQS) A list of current response type enums applied to
 	// the event source mapping.
 	FunctionResponseTypes []*string `json:"functionResponseTypes,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -77,6 +77,9 @@ resources:
       UUID:
         is_primary_key: true
       FunctionName:
+        references:
+          resource: Function
+          path: Spec.Name
         is_required: true
       FilterCriteria:
         compare:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -984,6 +984,11 @@ func (in *EventSourceMappingSpec) DeepCopyInto(out *EventSourceMappingSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FunctionRef != nil {
+		in, out := &in.FunctionRef, &out.FunctionRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FunctionResponseTypes != nil {
 		in, out := &in.FunctionResponseTypes, &out.FunctionResponseTypes
 		*out = make([]*string, len(*in))

--- a/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: eventsourcemappings.lambda.services.k8s.aws
 spec:
@@ -42,13 +41,13 @@ spec:
                   pulls from your stream or queue and sends to your function. Lambda
                   passes all of the records in the batch to the function in a single
                   call, up to the payload limit for synchronous invocation (6 MB).
-                  \n    * Amazon Kinesis - Default 100. Max 10,000. \n    * Amazon
-                  DynamoDB Streams - Default 100. Max 10,000. \n    * Amazon Simple
-                  Queue Service - Default 10. For standard queues the max    is 10,000.
-                  For FIFO queues the max is 10. \n    * Amazon Managed Streaming
-                  for Apache Kafka - Default 100. Max 10,000. \n    * Self-Managed
-                  Apache Kafka - Default 100. Max 10,000. \n    * Amazon MQ (ActiveMQ
-                  and RabbitMQ) - Default 100. Max 10,000."
+                  \n * Amazon Kinesis - Default 100. Max 10,000. \n * Amazon DynamoDB
+                  Streams - Default 100. Max 10,000. \n * Amazon Simple Queue Service
+                  - Default 10. For standard queues the max is 10,000. For FIFO queues
+                  the max is 10. \n * Amazon Managed Streaming for Apache Kafka -
+                  Default 100. Max 10,000. \n * Self-Managed Apache Kafka - Default
+                  100. Max 10,000. \n * Amazon MQ (ActiveMQ and RabbitMQ) - Default
+                  100. Max 10,000."
                 format: int64
                 type: integer
               bisectBatchOnFunctionError:
@@ -78,10 +77,10 @@ spec:
                 type: boolean
               eventSourceARN:
                 description: "The Amazon Resource Name (ARN) of the event source.
-                  \n    * Amazon Kinesis - The ARN of the data stream or a stream
-                  consumer. \n    * Amazon DynamoDB Streams - The ARN of the stream.
-                  \n    * Amazon Simple Queue Service - The ARN of the queue. \n    *
-                  Amazon Managed Streaming for Apache Kafka - The ARN of the cluster."
+                  \n * Amazon Kinesis - The ARN of the data stream or a stream consumer.
+                  \n * Amazon DynamoDB Streams - The ARN of the stream. \n * Amazon
+                  Simple Queue Service - The ARN of the queue. \n * Amazon Managed
+                  Streaming for Apache Kafka - The ARN of the cluster."
                 type: string
               filterCriteria:
                 description: (Streams and Amazon SQS) An object that defines the filter
@@ -100,12 +99,25 @@ spec:
                 type: object
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
-                  \n    * Version or Alias ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction:PROD.
-                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  * Function name - MyFunction. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n * Version or Alias ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction:PROD.
+                  \n * Partial ARN - 123456789012:function:MyFunction. \n The length
                   constraint applies only to the full ARN. If you specify only the
                   function name, it's limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               functionResponseTypes:
                 description: (Streams and Amazon SQS) A list of current response type
                   enums applied to the event source mapping.
@@ -186,8 +198,6 @@ spec:
                   window. The range is between 1 second up to 900 seconds.
                 format: int64
                 type: integer
-            required:
-            - functionName
             type: object
           status:
             description: EventSourceMappingStatus defines the observed state of EventSourceMapping
@@ -282,9 +292,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/generator.yaml
+++ b/generator.yaml
@@ -77,6 +77,9 @@ resources:
       UUID:
         is_primary_key: true
       FunctionName:
+        references:
+          resource: Function
+          path: Spec.Name
         is_required: true
       FilterCriteria:
         compare:

--- a/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: eventsourcemappings.lambda.services.k8s.aws
 spec:
@@ -42,13 +41,13 @@ spec:
                   pulls from your stream or queue and sends to your function. Lambda
                   passes all of the records in the batch to the function in a single
                   call, up to the payload limit for synchronous invocation (6 MB).
-                  \n    * Amazon Kinesis - Default 100. Max 10,000. \n    * Amazon
-                  DynamoDB Streams - Default 100. Max 10,000. \n    * Amazon Simple
-                  Queue Service - Default 10. For standard queues the max    is 10,000.
-                  For FIFO queues the max is 10. \n    * Amazon Managed Streaming
-                  for Apache Kafka - Default 100. Max 10,000. \n    * Self-Managed
-                  Apache Kafka - Default 100. Max 10,000. \n    * Amazon MQ (ActiveMQ
-                  and RabbitMQ) - Default 100. Max 10,000."
+                  \n * Amazon Kinesis - Default 100. Max 10,000. \n * Amazon DynamoDB
+                  Streams - Default 100. Max 10,000. \n * Amazon Simple Queue Service
+                  - Default 10. For standard queues the max is 10,000. For FIFO queues
+                  the max is 10. \n * Amazon Managed Streaming for Apache Kafka -
+                  Default 100. Max 10,000. \n * Self-Managed Apache Kafka - Default
+                  100. Max 10,000. \n * Amazon MQ (ActiveMQ and RabbitMQ) - Default
+                  100. Max 10,000."
                 format: int64
                 type: integer
               bisectBatchOnFunctionError:
@@ -78,10 +77,10 @@ spec:
                 type: boolean
               eventSourceARN:
                 description: "The Amazon Resource Name (ARN) of the event source.
-                  \n    * Amazon Kinesis - The ARN of the data stream or a stream
-                  consumer. \n    * Amazon DynamoDB Streams - The ARN of the stream.
-                  \n    * Amazon Simple Queue Service - The ARN of the queue. \n    *
-                  Amazon Managed Streaming for Apache Kafka - The ARN of the cluster."
+                  \n * Amazon Kinesis - The ARN of the data stream or a stream consumer.
+                  \n * Amazon DynamoDB Streams - The ARN of the stream. \n * Amazon
+                  Simple Queue Service - The ARN of the queue. \n * Amazon Managed
+                  Streaming for Apache Kafka - The ARN of the cluster."
                 type: string
               filterCriteria:
                 description: (Streams and Amazon SQS) An object that defines the filter
@@ -100,12 +99,25 @@ spec:
                 type: object
               functionName:
                 description: "The name of the Lambda function. \n Name formats \n
-                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
-                  \n    * Version or Alias ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction:PROD.
-                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  * Function name - MyFunction. \n * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n * Version or Alias ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction:PROD.
+                  \n * Partial ARN - 123456789012:function:MyFunction. \n The length
                   constraint applies only to the full ARN. If you specify only the
                   function name, it's limited to 64 characters in length."
                 type: string
+              functionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef: from: name: my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               functionResponseTypes:
                 description: (Streams and Amazon SQS) A list of current response type
                   enums applied to the event source mapping.
@@ -186,8 +198,6 @@ spec:
                   window. The range is between 1 second up to 900 seconds.
                 format: int64
                 type: integer
-            required:
-            - functionName
             type: object
           status:
             description: EventSourceMappingStatus defines the observed state of EventSourceMapping
@@ -282,9 +292,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/resource/event_source_mapping/delta.go
+++ b/pkg/resource/event_source_mapping/delta.go
@@ -103,6 +103,9 @@ func newResourceDelta(
 			delta.Add("Spec.FunctionName", a.ko.Spec.FunctionName, b.ko.Spec.FunctionName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef) {
+		delta.Add("Spec.FunctionRef", a.ko.Spec.FunctionRef, b.ko.Spec.FunctionRef)
+	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.FunctionResponseTypes, b.ko.Spec.FunctionResponseTypes) {
 		delta.Add("Spec.FunctionResponseTypes", a.ko.Spec.FunctionResponseTypes, b.ko.Spec.FunctionResponseTypes)
 	}

--- a/pkg/resource/event_source_mapping/references.go
+++ b/pkg/resource/event_source_mapping/references.go
@@ -17,8 +17,15 @@ package event_source_mapping
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/lambda-controller/apis/v1alpha1"
@@ -36,17 +43,95 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForFunctionName(ctx, apiReader, namespace, ko)
+	}
+
+	// If there was an error while resolving any reference, reset all the
+	// resolved values so that they do not get persisted inside etcd
+	if err != nil {
+		ko = rm.concreteResource(res).ko.DeepCopy()
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.EventSourceMapping) error {
+	if ko.Spec.FunctionRef != nil && ko.Spec.FunctionName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("FunctionName", "FunctionRef")
+	}
+	if ko.Spec.FunctionRef == nil && ko.Spec.FunctionName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionName", "FunctionRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.EventSourceMapping) bool {
-	return false
+	return false || (ko.Spec.FunctionRef != nil)
+}
+
+// resolveReferenceForFunctionName reads the resource referenced
+// from FunctionRef field and sets the FunctionName
+// from referenced resource
+func resolveReferenceForFunctionName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.EventSourceMapping,
+) error {
+	if ko.Spec.FunctionRef != nil &&
+		ko.Spec.FunctionRef.From != nil {
+		arr := ko.Spec.FunctionRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.Function{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Function",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"Function",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Function",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.FunctionName = &referencedValue
+	}
+	return nil
 }

--- a/test/e2e/resources/event_source_mapping_sqs_ref.yaml
+++ b/test/e2e/resources/event_source_mapping_sqs_ref.yaml
@@ -1,0 +1,14 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: EventSourceMapping
+metadata:
+  name: $EVENT_SOURCE_MAPPING_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  functionRef:
+    from:
+      name: $FUNCTION_REF_NAME
+  eventSourceARN: $EVENT_SOURCE_ARN
+  batchSize: $BATCH_SIZE
+  maximumBatchingWindowInSeconds: $MAXIMUM_BATCHING_WINDOW_IN_SECONDS
+  enabled: false


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adding functionality to the lambda controller to be able to reference a Function from a EventSourceMappingSQS resource using resource references.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
