### PR TITLE
Fixing `VPC.SubnetID` reference type

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-10-14T20:13:10Z"
+  build_date: "2022-10-17T20:12:02Z"
   build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
   go_version: go1.19
   version: v0.19.3-11-g5ee0ac0-dirty
@@ -7,7 +7,7 @@ api_directory_checksum: 33517b27f08163345ca25ea0d08179bd59580742
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 0f3c62b7a066343d08fa0a605bcc2011c39e788e
+  file_checksum: fc936f6c681c03e4ad3d8eaa5588c9acb3caabe1
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -10,8 +10,8 @@ resources:
     fields:
       VPCConfig.SubnetIDs:
         references:
-          resource: VPC
-          path: Status.VPCID
+          resource: Subnet
+          path: Status.SubnetID
           service_name: ec2
       KMSKeyARN:
         references:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -34,14 +34,14 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
-  - vpcs
+  - subnets
   verbs:
   - get
   - list
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
-  - vpcs/status
+  - subnets/status
   verbs:
   - get
   - list

--- a/generator.yaml
+++ b/generator.yaml
@@ -10,8 +10,8 @@ resources:
     fields:
       VPCConfig.SubnetIDs:
         references:
-          resource: VPC
-          path: Status.VPCID
+          resource: Subnet
+          path: Status.SubnetID
           service_name: ec2
       KMSKeyARN:
         references:

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -49,14 +49,14 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
-  - vpcs
+  - subnets
   verbs:
   - get
   - list
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
-  - vpcs/status
+  - subnets/status
   verbs:
   - get
   - list

--- a/pkg/resource/function/references.go
+++ b/pkg/resource/function/references.go
@@ -36,8 +36,8 @@ import (
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
-// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcs,verbs=get;list
-// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcs/status,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -174,7 +174,7 @@ func resolveReferenceForVPCConfig_SubnetIDs(
 				Namespace: namespace,
 				Name:      *arr.Name,
 			}
-			obj := ec2apitypes.VPC{}
+			obj := ec2apitypes.Subnet{}
 			err := apiReader.Get(ctx, namespacedName, &obj)
 			if err != nil {
 				return err
@@ -192,21 +192,21 @@ func resolveReferenceForVPCConfig_SubnetIDs(
 			}
 			if refResourceTerminal {
 				return ackerr.ResourceReferenceTerminalFor(
-					"VPC",
+					"Subnet",
 					namespace, *arr.Name)
 			}
 			if !refResourceSynced {
 				return ackerr.ResourceReferenceNotSyncedFor(
-					"VPC",
+					"Subnet",
 					namespace, *arr.Name)
 			}
-			if obj.Status.VPCID == nil {
+			if obj.Status.SubnetID == nil {
 				return ackerr.ResourceReferenceMissingTargetFieldFor(
-					"VPC",
+					"Subnet",
 					namespace, *arr.Name,
-					"Status.VPCID")
+					"Status.SubnetID")
 			}
-			referencedValue := string(*obj.Status.VPCID)
+			referencedValue := string(*obj.Status.SubnetID)
 			resolvedReferences = append(resolvedReferences, &referencedValue)
 		}
 		ko.Spec.VPCConfig.SubnetIDs = resolvedReferences


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixing VPC.SubnetIdRef resource. Correcting the reference path and resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
