### PR TITLE
Add resource reference for Amazon MQ brokers in `EventSourceMapping` resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-10-25T17:58:30Z"
-  build_hash: 9727031b415481d9ac28bb94cac9f1e73336401d
+  build_date: "2022-11-04T23:25:04Z"
+  build_hash: 7cd74c3a855e38ea3fb5e1cf40b26fbe96283870
   go_version: go1.19
-  version: v0.19.3-9-g9727031
-api_directory_checksum: e2da75eafa3ab7fe7cc4c8c26ba01e495e31d494
+  version: v0.19.3-15-g7cd74c3-dirty
+api_directory_checksum: f01a03847a7bb58e935fdca90ecfb910f645ea61
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 1328b65627cf7280ef4df6c1b0435653e99fe62f
+  file_checksum: 8c3d1a125902512d09de13f6ff4337e07a5518f0
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/event_source_mapping.go
+++ b/apis/v1alpha1/event_source_mapping.go
@@ -103,7 +103,8 @@ type EventSourceMappingSpec struct {
 	// are retried until the record expires.
 	MaximumRetryAttempts *int64 `json:"maximumRetryAttempts,omitempty"`
 	// (Streams only) The number of batches to process from each shard concurrently.
-	ParallelizationFactor *int64 `json:"parallelizationFactor,omitempty"`
+	ParallelizationFactor *int64                                     `json:"parallelizationFactor,omitempty"`
+	QueueRefs             []*ackv1alpha1.AWSResourceReferenceWrapper `json:"queueRefs,omitempty"`
 	// (MQ) The name of the Amazon MQ broker destination queue to consume.
 	Queues []*string `json:"queues,omitempty"`
 	// The self-managed Apache Kafka cluster to receive records from.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -97,6 +97,11 @@ resources:
       ignore: true
   EventSourceMapping:
     fields:
+      Queues:
+        references:
+          resource: Broker
+          path: Status.BrokerID
+          service_name: mq
       UUID:
         is_primary_key: true
       FunctionName:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1060,6 +1060,17 @@ func (in *EventSourceMappingSpec) DeepCopyInto(out *EventSourceMappingSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.QueueRefs != nil {
+		in, out := &in.QueueRefs, &out.QueueRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.Queues != nil {
 		in, out := &in.Queues, &out.Queues
 		*out = make([]*string, len(*in))

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,6 +20,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
+	mqapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -61,6 +62,7 @@ func init() {
 	_ = ackv1alpha1.AddToScheme(scheme)
 	_ = ec2apitypes.AddToScheme(scheme)
 	_ = kmsapitypes.AddToScheme(scheme)
+	_ = mqapitypes.AddToScheme(scheme)
 	_ = s3apitypes.AddToScheme(scheme)
 }
 

--- a/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -155,6 +155,22 @@ spec:
                   each shard concurrently.
                 format: int64
                 type: integer
+              queueRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               queues:
                 description: (MQ) The name of the Amazon MQ broker destination queue
                   to consume.

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -174,6 +174,20 @@ rules:
   - patch
   - update
 - apiGroups:
+  - mq.services.k8s.aws
+  resources:
+  - brokers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - mq.services.k8s.aws
+  resources:
+  - brokers/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - s3.services.k8s.aws
   resources:
   - buckets

--- a/generator.yaml
+++ b/generator.yaml
@@ -97,6 +97,11 @@ resources:
       ignore: true
   EventSourceMapping:
     fields:
+      Queues:
+        references:
+          resource: Broker
+          path: Status.BrokerID
+          service_name: mq
       UUID:
         is_primary_key: true
       FunctionName:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/aws-controllers-k8s/ec2-controller v0.0.21
 	github.com/aws-controllers-k8s/kms-controller v0.1.2
+	github.com/aws-controllers-k8s/mq-controller v0.0.22
 	github.com/aws-controllers-k8s/runtime v0.20.1
 	github.com/aws-controllers-k8s/s3-controller v0.1.5
 	github.com/aws/aws-sdk-go v1.44.93

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/aws-controllers-k8s/ec2-controller v0.0.21 h1:5O7/9aED2Tl9OT0TL2rWrc1
 github.com/aws-controllers-k8s/ec2-controller v0.0.21/go.mod h1:OMsmJeJ3iQZ1sJgs3hqnjBRnJ3hmTzJUO38W5rxnB5M=
 github.com/aws-controllers-k8s/kms-controller v0.1.2 h1:9lb98jspqOpFpmIFHOJ6pRnOkC8kDEPIgTAb5QnVGZo=
 github.com/aws-controllers-k8s/kms-controller v0.1.2/go.mod h1:6CoV0UMFd03EUF9dXgOTTScGdBhJzsWn9W0dw2n0kA4=
+github.com/aws-controllers-k8s/mq-controller v0.0.22 h1:XxFSQL9yaaiiuZ6E/fh/+Y9C+3DG2c5oXWG/4ZNwd1w=
+github.com/aws-controllers-k8s/mq-controller v0.0.22/go.mod h1:p+YVFjpwlgRC+1cPeCabk1xTB1hTCU+RwYtFzrTnJmE=
 github.com/aws-controllers-k8s/runtime v0.20.0/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws-controllers-k8s/runtime v0.20.1 h1:L/Huf1shRahx5BqJBCSS5u+vYg3f0Rotsq1jutORpdI=
 github.com/aws-controllers-k8s/runtime v0.20.1/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=

--- a/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -155,6 +155,22 @@ spec:
                   each shard concurrently.
                 format: int64
                 type: integer
+              queueRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               queues:
                 description: (MQ) The name of the Amazon MQ broker destination queue
                   to consume.

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -4,11 +4,19 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: ack-lambda-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{ else }}
 kind: Role
 metadata:
   creationTimestamp: null
   name: ack-lambda-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 rules:
@@ -180,6 +188,20 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - mq.services.k8s.aws
+  resources:
+  - brokers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - mq.services.k8s.aws
+  resources:
+  - brokers/status
+  verbs:
+  - get
+  - list
 - apiGroups:
   - s3.services.k8s.aws
   resources:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -65,6 +65,14 @@
       ],
       "type": "object"
     },
+    "role": {
+      "description": "Role settings",
+      "properties": {
+        "labels": {
+	  "type": "object"
+	}
+      }
+    },
     "metrics": {
       "description": "Metrics settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,10 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+# If "installScope: cluster" then these labels will be applied to ClusterRole
+role:
+ labels: {}
   
 metrics:
   service:

--- a/pkg/resource/event_source_mapping/delta.go
+++ b/pkg/resource/event_source_mapping/delta.go
@@ -148,6 +148,9 @@ func newResourceDelta(
 			delta.Add("Spec.ParallelizationFactor", a.ko.Spec.ParallelizationFactor, b.ko.Spec.ParallelizationFactor)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.QueueRefs, b.ko.Spec.QueueRefs) {
+		delta.Add("Spec.QueueRefs", a.ko.Spec.QueueRefs, b.ko.Spec.QueueRefs)
+	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.Queues, b.ko.Spec.Queues) {
 		delta.Add("Spec.Queues", a.ko.Spec.Queues, b.ko.Spec.Queues)
 	}

--- a/pkg/resource/event_source_mapping/references.go
+++ b/pkg/resource/event_source_mapping/references.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	mqapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
@@ -30,6 +31,9 @@ import (
 
 	svcapitypes "github.com/aws-controllers-k8s/lambda-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers,verbs=get;list
+// +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -48,6 +52,9 @@ func (rm *resourceManager) ResolveReferences(
 	err := validateReferenceFields(ko)
 	if err == nil {
 		err = resolveReferenceForFunctionName(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForQueues(ctx, apiReader, namespace, ko)
 	}
 
 	// If there was an error while resolving any reference, reset all the
@@ -70,13 +77,16 @@ func validateReferenceFields(ko *svcapitypes.EventSourceMapping) error {
 	if ko.Spec.FunctionRef == nil && ko.Spec.FunctionName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionName", "FunctionRef")
 	}
+	if ko.Spec.QueueRefs != nil && ko.Spec.Queues != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Queues", "QueueRefs")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.EventSourceMapping) bool {
-	return false || (ko.Spec.FunctionRef != nil)
+	return false || (ko.Spec.FunctionRef != nil) || (ko.Spec.QueueRefs != nil)
 }
 
 // resolveReferenceForFunctionName reads the resource referenced
@@ -132,6 +142,67 @@ func resolveReferenceForFunctionName(
 		}
 		referencedValue := string(*obj.Spec.Name)
 		ko.Spec.FunctionName = &referencedValue
+	}
+	return nil
+}
+
+// resolveReferenceForQueues reads the resource referenced
+// from QueueRefs field and sets the Queues
+// from referenced resource
+func resolveReferenceForQueues(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.EventSourceMapping,
+) error {
+	if ko.Spec.QueueRefs != nil &&
+		len(ko.Spec.QueueRefs) > 0 {
+		resolvedReferences := []*string{}
+		for _, arrw := range ko.Spec.QueueRefs {
+			arr := arrw.From
+			if arr == nil || arr.Name == nil || *arr.Name == "" {
+				return fmt.Errorf("provided resource reference is nil or empty")
+			}
+			namespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      *arr.Name,
+			}
+			obj := mqapitypes.Broker{}
+			err := apiReader.Get(ctx, namespacedName, &obj)
+			if err != nil {
+				return err
+			}
+			var refResourceSynced, refResourceTerminal bool
+			for _, cond := range obj.Status.Conditions {
+				if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceSynced = true
+				}
+				if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceTerminal = true
+				}
+			}
+			if refResourceTerminal {
+				return ackerr.ResourceReferenceTerminalFor(
+					"Broker",
+					namespace, *arr.Name)
+			}
+			if !refResourceSynced {
+				return ackerr.ResourceReferenceNotSyncedFor(
+					"Broker",
+					namespace, *arr.Name)
+			}
+			if obj.Status.BrokerID == nil {
+				return ackerr.ResourceReferenceMissingTargetFieldFor(
+					"Broker",
+					namespace, *arr.Name,
+					"Status.BrokerID")
+			}
+			referencedValue := string(*obj.Status.BrokerID)
+			resolvedReferences = append(resolvedReferences, &referencedValue)
+		}
+		ko.Spec.Queues = resolvedReferences
 	}
 	return nil
 }

--- a/pkg/resource/function/references.go
+++ b/pkg/resource/function/references.go
@@ -127,7 +127,6 @@ func resolveReferenceForCode_S3Bucket(
 	if ko.Spec.Code == nil {
 		return nil
 	}
-	//is nested
 	if ko.Spec.Code.S3BucketRef != nil &&
 		ko.Spec.Code.S3BucketRef.From != nil {
 		arr := ko.Spec.Code.S3BucketRef.From


### PR DESCRIPTION
Instead of manually passing the broker name, this feature will allow ACK lambda-controller users to cross-reference ACK MQ broker in their EventSourceMapping resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
