### PR TITLE
Adding delete all layer versions functionality for layerVersion resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: 8002bb4a0dad2ac145a596554897088e82ea3823
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.181
 generator_config_info:
-  file_checksum: e007d88ecf6ad1c45cb6451f5fda9401af9d7305
+  file_checksum: 095af1082df5c34cdc12296dc085bc6b2b7eadb9
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -153,6 +153,9 @@ resources:
             operation: ReadOne
     tags:
       ignore: true
+    hooks:
+      sdk_delete_pre_build_request:
+        template_path: hooks/layer_version/sdk_delete_pre_build_request.go.tpl
     renames:
       operations:
         GetLayerVersion:

--- a/generator.yaml
+++ b/generator.yaml
@@ -153,6 +153,9 @@ resources:
             operation: ReadOne
     tags:
       ignore: true
+    hooks:
+      sdk_delete_pre_build_request:
+        template_path: hooks/layer_version/sdk_delete_pre_build_request.go.tpl
     renames:
       operations:
         GetLayerVersion:

--- a/pkg/resource/layer_version/hooks.go
+++ b/pkg/resource/layer_version/hooks.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package layer_version
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/lambda"
+)
+
+// customPreDelete deletes all the previous versions of a
+// LayerVersion except the latest version
+// This function is used as a sdk_delete hook, to delete all the previous versions of a LayerVersion when delete API call is made
+func customPreDelete(
+	r *resource,
+	rm *resourceManager,
+	ctx context.Context,
+) error {
+	// Getting the list of all the versions of a LayerVersion
+	input := &svcsdk.ListLayerVersionsInput{
+		LayerName: r.ko.Spec.LayerName,
+	}
+	response, err := rm.sdkapi.ListLayerVersionsWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	log := ackrtlog.FromContext(ctx)
+	log.Debug("Deleting previous versions of LayerVersion")
+
+	// The above API call returns output containing list of versions as LayerVersions and a pagination token as NextMarker
+
+	// Extracting the list of versions and assigning it to a new variable
+	versionList := response.LayerVersions
+
+	// sorting the list in ascending order
+	sort.Slice(versionList, func(i, j int) bool {
+		return *versionList[i].Version < *versionList[j].Version
+	})
+
+	for i := 0; i < len(versionList)-1; i++ {
+		input := &svcsdk.DeleteLayerVersionInput{
+			LayerName:     r.ko.Spec.LayerName,
+			VersionNumber: versionList[i].Version,
+		}
+		// Delete API call to delete the versions one by one
+		logMessage := fmt.Sprintf("Deleting version %v of %v", *input.VersionNumber, *input.LayerName)
+		log.Debug(logMessage)
+
+		_, err = rm.sdkapi.DeleteLayerVersionWithContext(ctx, input)
+		rm.metrics.RecordAPICall("DELETE", "DeleteLayerVersion", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/resource/layer_version/sdk.go
+++ b/pkg/resource/layer_version/sdk.go
@@ -468,6 +468,9 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
+	if err = customPreDelete(r, rm, ctx); err != nil {
+		return nil, err
+	}
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return nil, err

--- a/templates/hooks/layer_version/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/layer_version/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,3 @@
+if err = customPreDelete(r,rm,ctx); err != nil{
+    return nil, err
+}

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -127,3 +127,13 @@ class LambdaValidator:
 
     def layer_version_exists(self, layer_name:str, version_number: int) -> bool:
         return self.get_layer_version(layer_name, version_number) is not None
+
+    def list_layer_versions(self, layer_name:str) -> list:
+        try:
+            resp = self.lambda_client.list_layer_versions(
+                LayerName = layer_name
+            )
+            return resp
+        except Exception as e:
+            logging.debug(e)
+            return None

--- a/test/e2e/tests/test_layer_version.py
+++ b/test/e2e/tests/test_layer_version.py
@@ -103,6 +103,11 @@ class TestLayerVersion:
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True
 
+        # Check if all versions are deleted
+        layer_name = cr['spec']['layerName']
+        list = lambda_validator.list_layer_versions(layer_name)
+        assert len(list["LayerVersions"]) == 0
+
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
         # Check layer version doesn't exist


### PR DESCRIPTION
Description of changes:
Currently when you delete a LayerVersion it deletes the most recent version of it and keep the previous versions. The functionality we want is to delete all the versions of a LayerVersion when DeleteLayerVersion is executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
