### PR TITLE
fix: update recommended IAM policy to include ecr:BatchGet*

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -6,7 +6,8 @@
             "Action": [
                 "lambda:*",
                 "s3:Get*",
-                "ecr:Get*"
+                "ecr:Get*",
+                "ecr:BatchGet*"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1641

Description of changes: Update recommended IAM policy for lambda controller to allow ecr:BatchGet*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
