### PR TITLE
Add functionality to pass reference of AmazonManagedKafka (MSK) in `EventSourceMapping` resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-06-07T18:16:37Z"
-  build_hash: dcb9fd6c564ce817a48abd6f7b9ee4308aa1d13f
+  build_date: "2023-06-27T22:12:27Z"
+  build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
   go_version: go1.19
-  version: v0.26.1-4-gdcb9fd6
-api_directory_checksum: ca34c731b281f29e80984c872002e220ddee5133
+  version: v0.26.1-7-ge9b6859
+api_directory_checksum: 5326aa7650a3899230ee809563bea350169fdca4
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.181
 generator_config_info:
-  file_checksum: d53a6ae44af0a12af854385908c6e09355b3a126
+  file_checksum: a9fdc0888330c561da4bf5f21d0f5afe48217935
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/event_source_mapping.go
+++ b/apis/v1alpha1/event_source_mapping.go
@@ -66,7 +66,8 @@ type EventSourceMappingSpec struct {
 	//   - Amazon Managed Streaming for Apache Kafka – The ARN of the cluster.
 	//
 	//   - Amazon MQ – The ARN of the broker.
-	EventSourceARN *string `json:"eventSourceARN,omitempty"`
+	EventSourceARN *string                                  `json:"eventSourceARN,omitempty"`
+	EventSourceRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventSourceRef,omitempty"`
 	// An object that defines the filter criteria that determine whether Lambda
 	// should process an event. For more information, see Lambda event filtering
 	// (https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html).

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -117,6 +117,11 @@ resources:
           resource: Broker
           path: Status.BrokerID
           service_name: mq
+      EventSourceARN:
+        references:
+          resource: Cluster
+          path: Status.ACKResourceMetadata.ARN
+          service_name: kafka
       UUID:
         is_primary_key: true
       FunctionName:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1019,6 +1019,11 @@ func (in *EventSourceMappingSpec) DeepCopyInto(out *EventSourceMappingSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EventSourceRef != nil {
+		in, out := &in.EventSourceRef, &out.EventSourceRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FilterCriteria != nil {
 		in, out := &in.FilterCriteria, &out.FilterCriteria
 		*out = new(FilterCriteria)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	kafkaapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	mqapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -63,6 +64,7 @@ func init() {
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
 	_ = ec2apitypes.AddToScheme(scheme)
+	_ = kafkaapitypes.AddToScheme(scheme)
 	_ = kmsapitypes.AddToScheme(scheme)
 	_ = mqapitypes.AddToScheme(scheme)
 	_ = s3apitypes.AddToScheme(scheme)

--- a/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -90,6 +90,19 @@ spec:
                   Streaming for Apache Kafka – The ARN of the cluster. \n * Amazon
                   MQ – The ARN of the broker."
                 type: string
+              eventSourceRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               filterCriteria:
                 description: An object that defines the filter criteria that determine
                   whether Lambda should process an event. For more information, see

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -60,6 +60,20 @@ rules:
   - get
   - list
 - apiGroups:
+  - kafka.services.k8s.aws
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kafka.services.k8s.aws
+  resources:
+  - clusters/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/generator.yaml
+++ b/generator.yaml
@@ -117,6 +117,11 @@ resources:
           resource: Broker
           path: Status.BrokerID
           service_name: mq
+      EventSourceARN:
+        references:
+          resource: Cluster
+          path: Status.ACKResourceMetadata.ARN
+          service_name: kafka
       UUID:
         is_primary_key: true
       FunctionName:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/aws-controllers-k8s/ec2-controller v0.0.21
+	github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1
 	github.com/aws-controllers-k8s/kms-controller v0.1.2
 	github.com/aws-controllers-k8s/mq-controller v0.0.22
 	github.com/aws-controllers-k8s/runtime v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21 h1:5O7/9aED2Tl9OT0TL2rWrc1Ix5V1UxYEgDKAhvFhPJQ=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21/go.mod h1:OMsmJeJ3iQZ1sJgs3hqnjBRnJ3hmTzJUO38W5rxnB5M=
+github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1 h1:NvmtIsm6fVoGUOvMfevONJETf+PtRWAiD3XzZBtQ2WA=
+github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1/go.mod h1:BHW00DFtXtugpsyn0nN0YdP32xmCN5p3lIJYP+Y0iVY=
 github.com/aws-controllers-k8s/kms-controller v0.1.2 h1:9lb98jspqOpFpmIFHOJ6pRnOkC8kDEPIgTAb5QnVGZo=
 github.com/aws-controllers-k8s/kms-controller v0.1.2/go.mod h1:6CoV0UMFd03EUF9dXgOTTScGdBhJzsWn9W0dw2n0kA4=
 github.com/aws-controllers-k8s/mq-controller v0.0.22 h1:XxFSQL9yaaiiuZ6E/fh/+Y9C+3DG2c5oXWG/4ZNwd1w=

--- a/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/helm/crds/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -90,6 +90,19 @@ spec:
                   Streaming for Apache Kafka – The ARN of the cluster. \n - Amazon
                   MQ – The ARN of the broker."
                 type: string
+              eventSourceRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               filterCriteria:
                 description: An object that defines the filter criteria that determine
                   whether Lambda should process an event. For more information, see

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -75,6 +75,20 @@ rules:
   - get
   - list
 - apiGroups:
+  - kafka.services.k8s.aws
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kafka.services.k8s.aws
+  resources:
+  - clusters/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -110,7 +110,7 @@ deletionPolicy: delete
 # controller reconciliation configurations
 reconcile:
   # The default duration, in seconds, to wait before resyncing desired state of custom resources.
-  defaultResyncPeriod: 0
+  defaultResyncPeriod: 36000 # 10 Hours
   # An object representing the reconcile resync configuration for each specific resource.
   resourceResyncPeriods: {}
 

--- a/pkg/resource/event_source_mapping/delta.go
+++ b/pkg/resource/event_source_mapping/delta.go
@@ -109,6 +109,9 @@ func newResourceDelta(
 			delta.Add("Spec.EventSourceARN", a.ko.Spec.EventSourceARN, b.ko.Spec.EventSourceARN)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.EventSourceRef, b.ko.Spec.EventSourceRef) {
+		delta.Add("Spec.EventSourceRef", a.ko.Spec.EventSourceRef, b.ko.Spec.EventSourceRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FunctionName, b.ko.Spec.FunctionName) {
 		delta.Add("Spec.FunctionName", a.ko.Spec.FunctionName, b.ko.Spec.FunctionName)
 	} else if a.ko.Spec.FunctionName != nil && b.ko.Spec.FunctionName != nil {


### PR DESCRIPTION
Issue #, if available: 
[#1394](https://github.com/aws-controllers-k8s/community/issues/1394)

Description of changes:

This PR adds functionality to pass reference for ARN of AmazonManagedKafka cluster to `EventSourceArn` in`EventSourceMapping` resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
