### PR TITLE
Add ability to reference role created by iam-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-06-28T18:32:11Z"
+  build_date: "2023-07-14T21:15:00Z"
   build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
-  go_version: go1.19
+  go_version: go1.20.5
   version: v0.26.1-7-ge9b6859
-api_directory_checksum: 5f162746e8495943dae5e96f48f4a3ab887b5be5
+api_directory_checksum: 5d5c7aea8863c47e7303cc870aad4250267d93d2
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.181
 generator_config_info:
-  file_checksum: ed4abfc994c2c47465801d301604c584bd743d41
+  file_checksum: dfaa004dd9551888415d54b3006e115cef3dbef3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/function.go
+++ b/apis/v1alpha1/function.go
@@ -108,8 +108,8 @@ type FunctionSpec struct {
 	// The number of simultaneous executions to reserve for the function.
 	ReservedConcurrentExecutions *int64 `json:"reservedConcurrentExecutions,omitempty"`
 	// The Amazon Resource Name (ARN) of the function's execution role.
-	// +kubebuilder:validation:Required
-	Role *string `json:"role"`
+	Role    *string                                  `json:"role,omitempty"`
+	RoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"roleRef,omitempty"`
 	// The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 	// Runtime is required if the deployment package is a .zip file archive.
 	Runtime *string `json:"runtime,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -39,6 +39,11 @@ resources:
           resource: Key
           path: Status.ACKResourceMetadata.ARN
           service_name: kms
+      Role:
+        references:
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
+          service_name: iam
       Name:
         is_primary_key: true
         is_required: true

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1793,6 +1793,11 @@ func (in *FunctionSpec) DeepCopyInto(out *FunctionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RoleRef != nil {
+		in, out := &in.RoleRef, &out.RoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Runtime != nil {
 		in, out := &in.Runtime, &out.Runtime
 		*out = new(string)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	kafkaapitypes "github.com/aws-controllers-k8s/kafka-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	mqapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
@@ -64,6 +65,7 @@ func init() {
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
 	_ = ec2apitypes.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
 	_ = kafkaapitypes.AddToScheme(scheme)
 	_ = kmsapitypes.AddToScheme(scheme)
 	_ = mqapitypes.AddToScheme(scheme)

--- a/config/crd/bases/lambda.services.k8s.aws_functions.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functions.yaml
@@ -235,6 +235,19 @@ spec:
                 description: The Amazon Resource Name (ARN) of the function's execution
                   role.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               runtime:
                 description: The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
                   Runtime is required if the deployment package is a .zip file archive.
@@ -321,7 +334,6 @@ spec:
             required:
             - code
             - name
-            - role
             type: object
           status:
             description: FunctionStatus defines the observed state of Function

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -60,6 +60,20 @@ rules:
   - get
   - list
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kafka.services.k8s.aws
   resources:
   - clusters

--- a/generator.yaml
+++ b/generator.yaml
@@ -39,6 +39,11 @@ resources:
           resource: Key
           path: Status.ACKResourceMetadata.ARN
           service_name: kms
+      Role:
+        references:
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
+          service_name: iam
       Name:
         is_primary_key: true
         is_required: true

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/aws-controllers-k8s/ec2-controller v0.0.21
+	github.com/aws-controllers-k8s/iam-controller v1.2.3
 	github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1
 	github.com/aws-controllers-k8s/kms-controller v0.1.2
 	github.com/aws-controllers-k8s/mq-controller v0.0.22

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21 h1:5O7/9aED2Tl9OT0TL2rWrc1Ix5V1UxYEgDKAhvFhPJQ=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21/go.mod h1:OMsmJeJ3iQZ1sJgs3hqnjBRnJ3hmTzJUO38W5rxnB5M=
+github.com/aws-controllers-k8s/iam-controller v1.2.3 h1:Vzz7/qxhcfkPrqn64Oi0tbvHetyiEto3gQuvpCSpECA=
+github.com/aws-controllers-k8s/iam-controller v1.2.3/go.mod h1:c7WaFwq2tIJjwpZhnuCYQ2ISzzMUJLTisPv92lim8sk=
 github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1 h1:NvmtIsm6fVoGUOvMfevONJETf+PtRWAiD3XzZBtQ2WA=
 github.com/aws-controllers-k8s/kafka-controller v0.0.0-20230615185632-102279061de1/go.mod h1:BHW00DFtXtugpsyn0nN0YdP32xmCN5p3lIJYP+Y0iVY=
 github.com/aws-controllers-k8s/kms-controller v0.1.2 h1:9lb98jspqOpFpmIFHOJ6pRnOkC8kDEPIgTAb5QnVGZo=

--- a/helm/crds/lambda.services.k8s.aws_functions.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functions.yaml
@@ -235,6 +235,19 @@ spec:
                 description: The Amazon Resource Name (ARN) of the function's execution
                   role.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               runtime:
                 description: The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
                   Runtime is required if the deployment package is a .zip file archive.
@@ -321,7 +334,6 @@ spec:
             required:
             - code
             - name
-            - role
             type: object
           status:
             description: FunctionStatus defines the observed state of Function

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -75,6 +75,20 @@ rules:
   - get
   - list
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kafka.services.k8s.aws
   resources:
   - clusters

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -234,6 +234,9 @@ func newResourceDelta(
 			delta.Add("Spec.Role", a.ko.Spec.Role, b.ko.Spec.Role)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.RoleRef, b.ko.Spec.RoleRef) {
+		delta.Add("Spec.RoleRef", a.ko.Spec.RoleRef, b.ko.Spec.RoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Runtime, b.ko.Spec.Runtime) {
 		delta.Add("Spec.Runtime", a.ko.Spec.Runtime, b.ko.Spec.Runtime)
 	} else if a.ko.Spec.Runtime != nil && b.ko.Spec.Runtime != nil {


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-controllers-k8s/community/issues/1835

**Description of changes:**

Adds ability to use `roleRef` instead of `role` to reference an IAM role created by the `iam-controller`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
