### PR TITLE
fix: catch race when role status is good but not yet ready to be assumed

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-07-17T22:50:01Z"
+  build_date: "2023-07-17T23:05:24Z"
   build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
   go_version: go1.20.5
   version: v0.26.1-7-ge9b6859

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-07-14T21:15:00Z"
+  build_date: "2023-07-17T22:50:01Z"
   build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
   go_version: go1.20.5
   version: v0.26.1-7-ge9b6859
@@ -7,7 +7,7 @@ api_directory_checksum: 5d5c7aea8863c47e7303cc870aad4250267d93d2
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.181
 generator_config_info:
-  file_checksum: dfaa004dd9551888415d54b3006e115cef3dbef3
+  file_checksum: ed3a099580e0fc1eb58db33a1bb1dfea6c8dbb7b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -68,7 +68,7 @@ resources:
           path: Configuration.Layers
       FunctionEventInvokeConfig:
         from:
-          operation: PutFunctionEventInvokeConfig 
+          operation: PutFunctionEventInvokeConfig
           path: .
     renames:
       operations:
@@ -89,6 +89,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_request:
+        template_path: hooks/function/sdk_create_post_request.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/function/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -104,7 +106,7 @@ resources:
         is_required: true
         references:
           resource: Function
-          path: Spec.Name 
+          path: Spec.Name
       FunctionVersion:
         is_required: true
       FunctionEventInvokeConfig:

--- a/generator.yaml
+++ b/generator.yaml
@@ -68,7 +68,7 @@ resources:
           path: Configuration.Layers
       FunctionEventInvokeConfig:
         from:
-          operation: PutFunctionEventInvokeConfig 
+          operation: PutFunctionEventInvokeConfig
           path: .
     renames:
       operations:
@@ -89,6 +89,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/function/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_request:
+        template_path: hooks/function/sdk_create_post_request.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/function/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -104,7 +106,7 @@ resources:
         is_required: true
         references:
           resource: Function
-          path: Spec.Name 
+          path: Spec.Name
       FunctionVersion:
         is_required: true
       FunctionEventInvokeConfig:

--- a/pkg/resource/function/hooks.go
+++ b/pkg/resource/function/hooks.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	ErrFunctionPending         = errors.New("function in 'Pending' state, cannot be modified or deleted")
+	ErrRoleCannotBeAssumed     = errors.New("The role defined for the function cannot be assumed by Lambda.")
 	ErrSourceImageDoesNotExist = errors.New("source image does not exist")
 	ErrCannotSetFunctionCSC    = errors.New("cannot set function code signing config when package type is Image")
 )
@@ -38,6 +39,10 @@ var (
 var (
 	requeueWaitWhilePending = ackrequeue.NeededAfter(
 		ErrFunctionPending,
+		5*time.Second,
+	)
+	requeueWaitWhileRoleCannotBeAssumed = ackrequeue.NeededAfter(
+		ErrRoleCannotBeAssumed,
 		5*time.Second,
 	)
 	requeueWaitWhileSourceImageDoesNotExist = ackrequeue.NeededAfter(

--- a/pkg/resource/function/hooks.go
+++ b/pkg/resource/function/hooks.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	ErrFunctionPending         = errors.New("function in 'Pending' state, cannot be modified or deleted")
-	ErrRoleCannotBeAssumed     = errors.New("The role defined for the function cannot be assumed by Lambda.")
+	ErrRoleCannotBeAssumed     = errors.New("the role defined for the function cannot be assumed by Lambda.")
 	ErrSourceImageDoesNotExist = errors.New("source image does not exist")
 	ErrCannotSetFunctionCSC    = errors.New("cannot set function code signing config when package type is Image")
 )

--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -447,6 +447,10 @@ func (rm *resourceManager) sdkCreate(
 	var resp *svcsdk.FunctionConfiguration
 	_ = resp
 	resp, err = rm.sdkapi.CreateFunctionWithContext(ctx, input)
+	if err != nil && strings.Contains(err.Error(), "The role defined for the function cannot be assumed by Lambda") {
+		return nil, requeueWaitWhileRoleCannotBeAssumed
+	}
+
 	rm.metrics.RecordAPICall("CREATE", "CreateFunction", err)
 	if err != nil {
 		return nil, err

--- a/templates/hooks/function/sdk_create_post_request.go.tpl
+++ b/templates/hooks/function/sdk_create_post_request.go.tpl
@@ -1,0 +1,3 @@
+	if err != nil && strings.Contains(err.Error(), "The role defined for the function cannot be assumed by Lambda") {
+		return nil, requeueWaitWhileRoleCannotBeAssumed
+	}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1835

Description of changes: Catches another race where the referenced role's status is good, but it can't be assumed yet. In this case, it just needs a few more seconds to propagate before the Function can be reconciled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
