### PR TITLE
Bug fix for `EventInvokeConfig` 

### DIFF
--- a/pkg/resource/function/hooks.go
+++ b/pkg/resource/function/hooks.go
@@ -497,41 +497,53 @@ func (rm *resourceManager) updateFunctionEventInvokeConfig(
 ) error {
 	var err error
 	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.updateFunctionEventInvokeConfig")
+	exit := rlog.Trace("rm.syncEventInvokeConfig")
 	defer exit(err)
+
+	// Check if the user deleted the 'FunctionEventInvokeConfig' configuration
+	// If yes, delete FunctionEventInvokeConfig
+	if desired.ko.Spec.FunctionEventInvokeConfig == nil {
+		input_delete := &svcsdk.DeleteFunctionEventInvokeConfigInput{
+			FunctionName: aws.String(*desired.ko.Spec.Name),
+		}
+		_, err = rm.sdkapi.DeleteFunctionEventInvokeConfigWithContext(ctx, input_delete)
+		rm.metrics.RecordAPICall("DELETE", "DeleteFunctionEventInvokeConfig", err)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	dspec := desired.ko.Spec
 	input := &svcsdk.PutFunctionEventInvokeConfigInput{
 		FunctionName: aws.String(*dspec.Name),
 	}
 
-	if desired.ko.Spec.FunctionEventInvokeConfig != nil {
-		if desired.ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds != nil {
-			input.MaximumEventAgeInSeconds = aws.Int64(*desired.ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds)
-		}
-		if desired.ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts != nil {
-			input.MaximumRetryAttempts = aws.Int64(*desired.ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts)
-		}
-		if desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig != nil {
-			destinations := &svcsdk.DestinationConfig{}
-			if desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnFailure != nil {
-				destinations.OnFailure = &svcsdk.OnFailure{}
-				if desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination != nil {
-					destinations.OnFailure.Destination = aws.String(*desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination)
-				}
+	if dspec.FunctionEventInvokeConfig.DestinationConfig != nil {
+		destinations := &svcsdk.DestinationConfig{}
+		if dspec.FunctionEventInvokeConfig.DestinationConfig.OnFailure != nil {
+			destinations.OnFailure = &svcsdk.OnFailure{}
+			if dspec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination != nil {
+				destinations.OnFailure.Destination = aws.String(*dspec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination)
 			}
-			if desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess != nil {
-				destinations.OnSuccess = &svcsdk.OnSuccess{}
-				if desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination != nil {
-					destinations.OnSuccess.Destination = aws.String(*desired.ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination)
-				}
-			}
-			input.DestinationConfig = destinations
 		}
+		if dspec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess != nil {
+			destinations.OnSuccess = &svcsdk.OnSuccess{}
+			if dspec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination != nil {
+				destinations.OnSuccess.Destination = aws.String(*dspec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination)
+			}
+		}
+		input.DestinationConfig = destinations
+	}
+	if dspec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds != nil {
+		input.MaximumEventAgeInSeconds = aws.Int64(*dspec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds)
+	}
+	if dspec.FunctionEventInvokeConfig.MaximumRetryAttempts != nil {
+		input.MaximumRetryAttempts = aws.Int64(*dspec.FunctionEventInvokeConfig.MaximumRetryAttempts)
 	}
 
 	_, err = rm.sdkapi.PutFunctionEventInvokeConfigWithContext(ctx, input)
-	rm.metrics.RecordAPICall("UPDATE", "PutFunctionEventInvokeConfig", err)
+	rm.metrics.RecordAPICall("UPDATE", "SyncEventInvokeConfig", err)
 	if err != nil {
 		return err
 	}
@@ -591,16 +603,11 @@ func (rm *resourceManager) deleteFunctionCodeSigningConfig(
 	return nil
 }
 
-// setResourceAdditionalFields will describe the fields that are not return by
-// GetFunctionConcurrency calls
-func (rm *resourceManager) setResourceAdditionalFields(
+// getFunctionConcurrency will describe the fields that are not return by GetFunctionConcurrency calls
+func (rm *resourceManager) getFunctionConcurrency(
 	ctx context.Context,
 	ko *svcapitypes.Function,
 ) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.setResourceAdditionalFields")
-	defer exit(err)
-
 	var getFunctionConcurrencyOutput *svcsdk.GetFunctionConcurrencyOutput
 	getFunctionConcurrencyOutput, err = rm.sdkapi.GetFunctionConcurrencyWithContext(
 		ctx,
@@ -614,6 +621,90 @@ func (rm *resourceManager) setResourceAdditionalFields(
 	}
 	ko.Spec.ReservedConcurrentExecutions = getFunctionConcurrencyOutput.ReservedConcurrentExecutions
 
+	return nil
+}
+
+// getFunctionCodeSigningConfig will describe the code signing
+// fields for the Function resource
+func (rm *resourceManager) getFunctionCodeSigningConfig(
+	ctx context.Context,
+	ko *svcapitypes.Function,
+) (err error) {
+	var getFunctionCodeSigningConfigOutput *svcsdk.GetFunctionCodeSigningConfigOutput
+	getFunctionCodeSigningConfigOutput, err = rm.sdkapi.GetFunctionCodeSigningConfigWithContext(
+		ctx,
+		&svcsdk.GetFunctionCodeSigningConfigInput{
+			FunctionName: ko.Spec.Name,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "GetFunctionCodeSigningConfig", err)
+	if err != nil {
+		return err
+	}
+	ko.Spec.CodeSigningConfigARN = getFunctionCodeSigningConfigOutput.CodeSigningConfigArn
+
+	return nil
+}
+
+func (rm *resourceManager) setFunctionEventInvokeConfigFromResponse(
+	ko *svcapitypes.Function,
+	getFunctionEventInvokeConfigOutput *svcsdk.GetFunctionEventInvokeConfigOutput,
+	apiError error,
+) (err error) {
+
+	if apiError != nil {
+		if awserr, ok := ackerr.AWSError(apiError); ok && (awserr.Code() == "EventInvokeConfigNotFoundException" || awserr.Code() == "ResourceNotFoundException") {
+			ko.Spec.FunctionEventInvokeConfig = nil
+		} else {
+			return apiError
+		}
+	} else {
+		if ko.Spec.FunctionEventInvokeConfig != nil {
+			if getFunctionEventInvokeConfigOutput.DestinationConfig != nil {
+				if getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure != nil {
+					if getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure.Destination != nil {
+						ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure.Destination
+					}
+				}
+				if getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess != nil {
+					if getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess.Destination != nil {
+						ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess.Destination
+					}
+				}
+			} else {
+				ko.Spec.FunctionEventInvokeConfig.DestinationConfig = nil
+			}
+			if getFunctionEventInvokeConfigOutput.MaximumEventAgeInSeconds != nil {
+				ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds = getFunctionEventInvokeConfigOutput.MaximumEventAgeInSeconds
+			} else {
+				ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds = nil
+			}
+			if getFunctionEventInvokeConfigOutput.DestinationConfig != nil {
+				ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts = getFunctionEventInvokeConfigOutput.MaximumRetryAttempts
+			} else {
+				ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts = nil
+			}
+		} else {
+			cloudFunctionEventInvokeConfig := &svcapitypes.PutFunctionEventInvokeConfigInput{}
+			cloudFunctionEventInvokeConfig.DestinationConfig = &svcapitypes.DestinationConfig{}
+			cloudFunctionEventInvokeConfig.DestinationConfig.OnFailure = &svcapitypes.OnFailure{}
+			cloudFunctionEventInvokeConfig.DestinationConfig.OnSuccess = &svcapitypes.OnSuccess{}
+			cloudFunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure.Destination
+			cloudFunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess.Destination
+			cloudFunctionEventInvokeConfig.MaximumEventAgeInSeconds = getFunctionEventInvokeConfigOutput.MaximumEventAgeInSeconds
+			cloudFunctionEventInvokeConfig.MaximumRetryAttempts = getFunctionEventInvokeConfigOutput.MaximumRetryAttempts
+			ko.Spec.FunctionEventInvokeConfig = cloudFunctionEventInvokeConfig
+		}
+	}
+	return nil
+}
+
+// getFunctionEventInvokeConfig will describe the fields that are
+// custom to the Function resource
+func (rm *resourceManager) getFunctionEventInvokeConfig(
+	ctx context.Context,
+	ko *svcapitypes.Function,
+) (err error) {
 	var getFunctionEventInvokeConfigOutput *svcsdk.GetFunctionEventInvokeConfigOutput
 	getFunctionEventInvokeConfigOutput, err = rm.sdkapi.GetFunctionEventInvokeConfigWithContext(
 		ctx,
@@ -622,55 +713,48 @@ func (rm *resourceManager) setResourceAdditionalFields(
 		},
 	)
 	rm.metrics.RecordAPICall("GET", "GetFunctionEventInvokeConfig", err)
+
+	err = rm.setFunctionEventInvokeConfigFromResponse(ko, getFunctionEventInvokeConfigOutput, err)
 	if err != nil {
-		if awserr, ok := ackerr.AWSError(err); ok && (awserr.Code() == "EventInvokeConfigNotFoundException" || awserr.Code() == "ResourceNotFoundException") {
-			ko.Spec.FunctionEventInvokeConfig = nil
-		} else {
-			return err
-		}
-	} else {
-		if getFunctionEventInvokeConfigOutput.DestinationConfig != nil {
-			if getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure != nil {
-				if getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure.Destination != nil {
-					ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnFailure.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnFailure.Destination
-				}
-			}
-			if getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess != nil {
-				if getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess.Destination != nil {
-					ko.Spec.FunctionEventInvokeConfig.DestinationConfig.OnSuccess.Destination = getFunctionEventInvokeConfigOutput.DestinationConfig.OnSuccess.Destination
-				}
-			}
-		} else {
-			ko.Spec.FunctionEventInvokeConfig.DestinationConfig = nil
-		}
-		if getFunctionEventInvokeConfigOutput.MaximumEventAgeInSeconds != nil {
-			ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds = getFunctionEventInvokeConfigOutput.MaximumEventAgeInSeconds
-		} else {
-			ko.Spec.FunctionEventInvokeConfig.MaximumEventAgeInSeconds = nil
-		}
-		if getFunctionEventInvokeConfigOutput.DestinationConfig != nil {
-			ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts = getFunctionEventInvokeConfigOutput.MaximumRetryAttempts
-		} else {
-			ko.Spec.FunctionEventInvokeConfig.MaximumRetryAttempts = nil
-		}
+		return err
 	}
+
+	return nil
+}
+
+// setResourceAdditionalFields will describe the fields that are not return by
+// API calls
+func (rm *resourceManager) setResourceAdditionalFields(
+	ctx context.Context,
+	ko *svcapitypes.Function,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setResourceAdditionalFields")
+	defer exit(err)
+
+	// To set Function Concurrency for the function
+	err = rm.getFunctionConcurrency(ctx, ko)
+	if err != nil {
+		return err
+	}
+
+	// To set Asynchronous Invocations for the function
+	err = rm.getFunctionEventInvokeConfig(ctx, ko)
+	if err != nil {
+		return err
+	}
+
+	// To set Code Signing Config based on the PackageType for the function
 	if ko.Spec.PackageType != nil && *ko.Spec.PackageType == "Zip" {
-		var getFunctionCodeSigningConfigOutput *svcsdk.GetFunctionCodeSigningConfigOutput
-		getFunctionCodeSigningConfigOutput, err = rm.sdkapi.GetFunctionCodeSigningConfigWithContext(
-			ctx,
-			&svcsdk.GetFunctionCodeSigningConfigInput{
-				FunctionName: ko.Spec.Name,
-			},
-		)
-		rm.metrics.RecordAPICall("GET", "GetFunctionCodeSigningConfig", err)
+		err = rm.getFunctionCodeSigningConfig(ctx, ko)
 		if err != nil {
 			return err
 		}
-		ko.Spec.CodeSigningConfigARN = getFunctionCodeSigningConfigOutput.CodeSigningConfigArn
 	}
 	if ko.Spec.PackageType != nil && *ko.Spec.PackageType == "Image" &&
 		ko.Spec.CodeSigningConfigARN != nil && *ko.Spec.CodeSigningConfigARN != "" {
 		return ackerr.NewTerminalError(ErrCannotSetFunctionCSC)
 	}
+
 	return nil
 }

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -335,6 +335,17 @@ class TestAlias:
         assert function_event_invoke_config["MaximumEventAgeInSeconds"] == 200
         assert function_event_invoke_config["MaximumRetryAttempts"] == 2
 
+        # Delete FunctionEventInvokeConfig
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr["spec"]["functionEventInvokeConfig"] =  None
+
+        # Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        # Check if FunctionEventInvokeConfig is deleted
+        assert not lambda_validator.get_function_event_invoke_config_alias(lambda_function_name,resource_name)
+
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -596,6 +596,17 @@ class TestFunction:
         assert function_event_invoke_config["MaximumEventAgeInSeconds"] == 200
         assert function_event_invoke_config["MaximumRetryAttempts"] == 2
         
+        # Delete FunctionEventInvokeConfig
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr["spec"]["functionEventInvokeConfig"] =  None
+
+        # Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        # Check if FunctionEventInvokeConfig is deleted
+        assert not lambda_validator.get_function_event_invoke_config(resource_name)
+
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True


### PR DESCRIPTION
Issue #, if available:
Related PR: #92 #93 

**Summary**
Fixing deletion part for `EventInvokeConfig` field.

**Description:**
This PR is related to bug fixes in [previous PR](https://github.com/aws-controllers-k8s/lambda-controller/pull/97) related to `EventInvokeConfig` implementation. When the user deleted the set configurations for Function/Alias resource, the configurations were not deleted from the Console side, instead it used to throw an error. Fixed the bug by introducing a new condition to check if the desired configurations are nil or not, if yes then call the delete API. 

Example of changes for `EventInvokeConfig` in Alias resource is given below:

```
if r.ko.Spec.FunctionEventInvokeConfig == nil {
	input_delete := &svcsdk.DeleteFunctionEventInvokeConfigInput{
		FunctionName: aws.String(*r.ko.Spec.FunctionName),
		Qualifier:    aws.String(*r.ko.Spec.Name),
	}
	_, err = rm.sdkapi.DeleteFunctionEventInvokeConfigWithContext(ctx, input_delete)
	rm.metrics.RecordAPICall("DELETE", "DeleteFunctionEventInvokeConfig", err)
	if err != nil {
		return nil, err
	}
	return r, nil
}
```

This PR contains implementation code and E2E test to validate the changes. 

**Acknowledgment**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.