### PR TITLE
adding support for sts vpc endpoint

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
+        - --aws-identity-endpoint-url
+        - "$(AWS_IDENTITY_ENDPOINT_URL)"
 {{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
 {{- end }}
@@ -89,6 +91,8 @@ spec:
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL
           value: {{ .Values.aws.endpoint_url | quote }}
+        - name: AWS_IDENTITY_ENDPOINT_URL
+          value: {{ .Values.aws.identity_endpoint_url | quote }}
         - name: ACK_WATCH_NAMESPACE
           value: {{ include "watch-namespace" . }}
         - name: DELETION_POLICY

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -87,6 +87,7 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   endpoint_url: ""
+  identity_endpoint_url: ""
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""


### PR DESCRIPTION
This PR adds support for setting the STS endpoint. This is required for environments that restrict outbound internet access and utilize VPC endpoints for access to AWS services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
