### PR TITLE
fix: Support to update `architectures` field

### DIFF
--- a/pkg/resource/function/sdk.go
+++ b/pkg/resource/function/sdk.go
@@ -117,6 +117,17 @@ func (rm *resourceManager) sdkFind(
 			ko.Spec.Code.ImageURI = resp.Code.ImageUri
 		}
 	}
+	if resp.Configuration.Architectures != nil {
+		f1 := []*string{}
+		for _, f1iter := range resp.Configuration.Architectures {
+			var f1elem string
+			f1elem = *f1iter
+			f1 = append(f1, &f1elem)
+		}
+		ko.Spec.Architectures = f1
+	} else {
+		ko.Spec.Architectures = nil
+	}
 	if resp.Configuration.CodeSha256 != nil {
 		ko.Status.CodeSHA256 = resp.Configuration.CodeSha256
 	} else {

--- a/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/function/sdk_read_one_post_set_output.go.tpl
@@ -12,6 +12,17 @@
 			ko.Spec.Code.ImageURI = resp.Code.ImageUri
 		}
 	}
+	if resp.Configuration.Architectures != nil {
+		f1 := []*string{}
+		for _, f1iter := range resp.Configuration.Architectures {
+			var f1elem string
+			f1elem = *f1iter
+			f1 = append(f1, &f1elem)
+		}
+		ko.Spec.Architectures = f1
+	} else {
+		ko.Spec.Architectures = nil
+	}
 	if resp.Configuration.CodeSha256 != nil {
 		ko.Status.CodeSHA256 = resp.Configuration.CodeSha256
 	} else {

--- a/test/e2e/resources/function_architectures.yaml
+++ b/test/e2e/resources/function_architectures.yaml
@@ -1,0 +1,18 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Function
+metadata:
+  name: $FUNCTION_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $FUNCTION_NAME
+  code:
+    s3Bucket: $BUCKET_NAME
+    s3Key: $LAMBDA_FILE_NAME
+  role: $LAMBDA_ROLE
+  architectures: [$ARCHITECTURES]
+  runtime: python3.9
+  handler: main
+  description: function created by ACK lambda-controller e2e tests
+  reservedConcurrentExecutions: $RESERVED_CONCURRENT_EXECUTIONS
+  codeSigningConfigARN: "$CODE_SIGNING_CONFIG_ARN"

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -539,6 +539,71 @@ class TestFunction:
         # Check Lambda function doesn't exist
         assert not lambda_validator.function_exists(resource_name)
 
+    def test_function_architecture(self, lambda_client):
+        resource_name = random_suffix_name("functionsarchitecture", 24)
+
+        resources = get_bootstrap_resources()
+        logging.debug(resources)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["FUNCTION_NAME"] = resource_name
+        replacements["BUCKET_NAME"] = resources.FunctionsBucket.name
+        replacements["LAMBDA_ROLE"] = resources.BasicRole.arn
+        replacements["LAMBDA_FILE_NAME"] = LAMBDA_FUNCTION_FILE_ZIP
+        replacements["RESERVED_CONCURRENT_EXECUTIONS"] = "0"
+        replacements["CODE_SIGNING_CONFIG_ARN"] = ""
+        replacements["AWS_REGION"] = get_region()
+        replacements["ARCHITECTURES"] = 'x86_64'
+
+        # Load Lambda CR
+        resource_data = load_lambda_resource(
+            "function_architectures",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        lambda_validator = LambdaValidator(lambda_client)
+
+        # Check Lambda function exists
+        assert lambda_validator.function_exists(resource_name)
+
+        # Update cr
+        cr["spec"]["architectures"] = ['arm64']
+        cr["spec"]["code"]["s3Bucket"] = resources.FunctionsBucket.name
+        cr["spec"]["code"]["s3Key"] = LAMBDA_FUNCTION_FILE_ZIP
+
+        #Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        #Check function_snapstart update fields
+        function = lambda_validator.get_function(resource_name)
+        assert function["Configuration"]["Architectures"] == ['arm64']
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check Lambda function doesn't exist
+        assert not lambda_validator.function_exists(resource_name)
+
     def test_function_event_invoke_config(self, lambda_client):
         resource_name = random_suffix_name("lambda-function", 24)
 


### PR DESCRIPTION
**Issue:**
[#1971](https://github.com/aws-controllers-k8s/community/issues/1971)

**Description:**
When updating `architectures` field for the function code, it was not recognized by the lambda-controller. This PR fixes that bug. Now controller recognizes the change in `architectures` field and updates it.

**Acknowledgement:**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
