### PR TITLE
fix: ensure function syncs when inactive

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-04-18T02:07:04Z"
+  build_date: "2025-04-29T21:53:05Z"
   build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
   go_version: go1.24.1
   version: v0.44.0-3-g0909e7f
@@ -7,7 +7,7 @@ api_directory_checksum: b37edb8bba9d3847d4bdf1e842b7a597821c8c37
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 3dbfbaabdb68f05226834184bacb6be1028ba38d
+  file_checksum: 5d39bbf411d4c83ce03ff295703199b5c5a215ac
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -59,7 +59,7 @@ resources:
     synced:
       when:
         - path: Status.State
-          in: [ "Active" ]
+          in: [ "Active", "Inactive" ]
     fields:
       Code.SHA256:
         type: string

--- a/generator.yaml
+++ b/generator.yaml
@@ -59,7 +59,7 @@ resources:
     synced:
       when:
         - path: Status.State
-          in: [ "Active" ]
+          in: [ "Active", "Inactive" ]
     fields:
       Code.SHA256:
         type: string

--- a/pkg/resource/function/manager.go
+++ b/pkg/resource/function/manager.go
@@ -271,7 +271,7 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 	if r.ko.Status.State == nil {
 		return false, nil
 	}
-	stateCandidates := []string{"Active"}
+	stateCandidates := []string{"Active", "Inactive"}
 	if !ackutil.InStrings(*r.ko.Status.State, stateCandidates) {
 		return false, nil
 	}


### PR DESCRIPTION
Issue [#2446](https://github.com/aws-controllers-k8s/community/issues/2446)

Description of changes:
Currently the controller only marks a function resource as synced only 
when it is active. We want to ensure we sync if it is inactive as well.

In Lambda function, inactive simply indicates that a function has been idle
for a long time, and we do not want the controller to keep requeueing 
indefinitely

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
