### PR TITLE
make alias name immutable

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-06-02T18:59:43Z"
+  build_date: "2025-06-04T17:39:33Z"
   build_hash: abd45b45e7726b7893641afaeae805281358e684
-  go_version: go1.24.2
-  version: v0.47.2
-api_directory_checksum: f450e33f8433d18a9b5ac9dbecc6d2652d4f8513
+  go_version: go1.24.1
+  version: v0.46.2-8-gabd45b4
+api_directory_checksum: ed9ce58c5e4f740c731e2a176ba4caaae66412fd
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: cf02b1eaffba7c5446d3fbfed24ba7496ae1cf4e
+  file_checksum: 84185fa62e82f46186de49d9ce2efb55e788cd28
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/alias.go
+++ b/apis/v1alpha1/alias.go
@@ -68,6 +68,7 @@ type AliasSpec struct {
 	// The name of the alias.
 	//
 	// Regex Pattern: `^(?!^[0-9]+$)([a-zA-Z0-9-_]+)$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
 	// Permissions configures a set of Lambda permissions to grant to an alias.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -147,6 +147,7 @@ resources:
     fields:
       Name:
         is_required: true
+        is_immutable: true
         is_primary_key: true
       FunctionName:
         is_required: true

--- a/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
@@ -140,6 +140,9 @@ spec:
 
                   Regex Pattern: `^(?!^[0-9]+$)([a-zA-Z0-9-_]+)$`
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               permissions:
                 description: Permissions configures a set of Lambda permissions to
                   grant to an alias.

--- a/generator.yaml
+++ b/generator.yaml
@@ -147,6 +147,7 @@ resources:
     fields:
       Name:
         is_required: true
+        is_immutable: true
         is_primary_key: true
       FunctionName:
         is_required: true

--- a/helm/crds/lambda.services.k8s.aws_aliases.yaml
+++ b/helm/crds/lambda.services.k8s.aws_aliases.yaml
@@ -140,6 +140,9 @@ spec:
 
                   Regex Pattern: `^(?!^[0-9]+$)([a-zA-Z0-9-_]+)$`
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               permissions:
                 description: Permissions configures a set of Lambda permissions to
                   grant to an alias.


### PR DESCRIPTION
Closes: https://github.com/aws-controllers-k8s/community/issues/1405#issuecomment-2839842918

Description of changes:
- make alias name immutable, required for `DeleteAlias` call

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
