### PR TITLE
fix: address lambda E2E test flaky timeout failures

### DIFF
--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -35,6 +35,11 @@ CREATE_WAIT_AFTER_SECONDS = 30
 UPDATE_WAIT_AFTER_SECONDS = 30
 DELETE_WAIT_AFTER_SECONDS = 30
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 @pytest.fixture(scope="module")
 def lambda_function():
         resource_name = random_suffix_name("lambda-function", 24)
@@ -64,7 +69,7 @@ def lambda_function():
 
         # Create lambda function
         k8s.create_custom_resource(function_reference, resource_data)
-        function_resource = k8s.wait_resource_consumed_by_controller(function_reference)
+        function_resource = k8s.wait_resource_consumed_by_controller(function_reference, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert function_resource is not None
         assert k8s.get_resource_exists(function_reference)
@@ -73,7 +78,7 @@ def lambda_function():
 
         yield (function_reference, function_resource)
 
-        _, deleted = k8s.delete_custom_resource(function_reference)
+        _, deleted = k8s.delete_custom_resource(function_reference, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
 
@@ -101,7 +106,7 @@ def lambda_alias(lambda_client, lambda_function):
         resource_name, namespace="default",
     )
     k8s.create_custom_resource(ref, resource_data)
-    cr = k8s.wait_resource_consumed_by_controller(ref)
+    cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
     assert cr is not None
     assert k8s.get_resource_exists(ref)
@@ -113,7 +118,7 @@ def lambda_alias(lambda_client, lambda_function):
     
     yield (ref, cr, lambda_function_name, resource_name)
     
-    _, deleted = k8s.delete_custom_resource(ref)
+    _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
     assert deleted
 
     time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -149,7 +154,7 @@ class TestAlias:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -160,7 +165,7 @@ class TestAlias:
         # Check alias exists
         assert lambda_validator.alias_exists(resource_name, lambda_function_name)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         
         # Update cr
         cr["spec"]["description"] = ""
@@ -175,7 +180,7 @@ class TestAlias:
         assert alias["Description"] == ""
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -208,7 +213,7 @@ class TestAlias:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -219,7 +224,7 @@ class TestAlias:
         # Check alias exists
         assert lambda_validator.alias_exists(resource_name, function_resource_name)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         
         # Update cr
         cr["spec"]["description"] = ""
@@ -234,7 +239,7 @@ class TestAlias:
         assert alias["Description"] == ""
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -277,14 +282,14 @@ class TestAlias:
         )
 
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -303,7 +308,7 @@ class TestAlias:
         assert provisioned_concurrency_config["RequestedProvisionedConcurrentExecutions"] == 2
 
         # Delete provisioned_concurrency from alias
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["provisionedConcurrencyConfig"] = None
 
         # Patch k8s resource     
@@ -314,7 +319,7 @@ class TestAlias:
         assert not lambda_validator.get_provisioned_concurrency_config(lambda_function_name, resource_name)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -354,14 +359,14 @@ class TestAlias:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -382,7 +387,7 @@ class TestAlias:
         assert function_event_invoke_config["MaximumRetryAttempts"] == 2
 
         # Delete FunctionEventInvokeConfig
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["functionEventInvokeConfig"] =  None
 
         # Patch k8s resource
@@ -393,7 +398,7 @@ class TestAlias:
         assert not lambda_validator.get_function_event_invoke_config_alias(lambda_function_name,resource_name)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -450,7 +455,7 @@ class TestAlias:
             }
         ]
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["permissions"] = updated_permissions
 
         k8s.patch_custom_resource(ref, cr)

--- a/test/e2e/tests/test_code_signing_config.py
+++ b/test/e2e/tests/test_code_signing_config.py
@@ -33,6 +33,11 @@ CREATE_WAIT_AFTER_SECONDS = 10
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 @service_marker
 @pytest.mark.canary
 class TestCodeSigningConfig:
@@ -60,7 +65,7 @@ class TestCodeSigningConfig:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -86,7 +91,7 @@ class TestCodeSigningConfig:
         assert csc["Description"] == "new description"
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_event_source_mapping.py
+++ b/test/e2e/tests/test_event_source_mapping.py
@@ -34,6 +34,11 @@ CREATE_WAIT_AFTER_SECONDS = 20
 UPDATE_WAIT_AFTER_SECONDS = 20
 DELETE_WAIT_AFTER_SECONDS = 20
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 @pytest.fixture(scope="module")
 def lambda_function():
         resource_name = random_suffix_name("lambda-function", 24)
@@ -63,7 +68,7 @@ def lambda_function():
 
         # Create lambda function
         k8s.create_custom_resource(function_reference, resource_data)
-        function_resource = k8s.wait_resource_consumed_by_controller(function_reference)
+        function_resource = k8s.wait_resource_consumed_by_controller(function_reference, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert function_resource is not None
         assert k8s.get_resource_exists(function_reference)
@@ -72,7 +77,7 @@ def lambda_function():
 
         yield (function_reference, function_resource)
 
-        _, deleted = k8s.delete_custom_resource(function_reference)
+        _, deleted = k8s.delete_custom_resource(function_reference, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
 @service_marker
@@ -106,7 +111,7 @@ class TestEventSourceMapping:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -147,7 +152,7 @@ class TestEventSourceMapping:
 
 
         # Delete the filterCriteria field
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["filterCriteria"] = None
 
         # Patch k8s resource
@@ -160,7 +165,7 @@ class TestEventSourceMapping:
         assert "FilterCriteria" not in esm
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -196,7 +201,7 @@ class TestEventSourceMapping:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -234,7 +239,7 @@ class TestEventSourceMapping:
         ]
 
         # Delete the filterCriteria field
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["filterCriteria"] = None
 
         # Patch k8s resource
@@ -247,7 +252,7 @@ class TestEventSourceMapping:
         assert "FilterCriteria" not in esm
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -284,7 +289,7 @@ class TestEventSourceMapping:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -316,7 +321,7 @@ class TestEventSourceMapping:
         assert esm["MaximumRetryAttempts"] == 3
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_function.py
+++ b/test/e2e/tests/test_function.py
@@ -38,6 +38,11 @@ CREATE_WAIT_AFTER_SECONDS = 30
 UPDATE_WAIT_AFTER_SECONDS = 30
 DELETE_WAIT_AFTER_SECONDS = 30
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 def get_testing_image_url():
     aws_region = get_region()
     account_id = get_account_id()
@@ -68,7 +73,7 @@ def code_signing_config():
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -77,7 +82,7 @@ def code_signing_config():
 
         yield (ref, cr)
 
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
 @service_marker
@@ -112,14 +117,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -161,7 +166,7 @@ class TestFunction:
         )
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -197,14 +202,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
         # Check Lambda function exists
@@ -225,7 +230,7 @@ class TestFunction:
         assert reservedConcurrentExecutions == 0
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -262,14 +267,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
         # Check Lambda function exists
@@ -289,7 +294,7 @@ class TestFunction:
         assert function_csc_arn is None
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -321,14 +326,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
         # Check Lambda function exists
@@ -347,7 +352,7 @@ class TestFunction:
         assert function["Configuration"]["EphemeralStorage"]["Size"] == 1024
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -379,14 +384,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
         # Check Lambda function exists
@@ -398,7 +403,7 @@ class TestFunction:
 
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         # assert condition
         assert k8s.assert_condition_state_message(
             ref,
@@ -407,7 +412,7 @@ class TestFunction:
             "cannot set function code signing config when package type is Image",
         )
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         # Remove signing configuration
         cr["spec"]["codeSigningConfigARN"] = ""
@@ -416,7 +421,7 @@ class TestFunction:
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
         
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -452,14 +457,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS*3)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
         # Check Lambda function exists
@@ -472,7 +477,7 @@ class TestFunction:
         assert function["Configuration"]["State"] == "Active"
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -508,14 +513,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -534,7 +539,7 @@ class TestFunction:
         assert function["Configuration"]["SnapStart"]["ApplyOn"] == "PublishedVersions"
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -571,14 +576,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -599,7 +604,7 @@ class TestFunction:
         assert function["Configuration"]["Architectures"] == ['arm64']
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -634,14 +639,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -660,7 +665,7 @@ class TestFunction:
         assert function["Configuration"]["DeadLetterConfig"]["TargetArn"] == resources.EICQueueOnFailure.arn
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -696,14 +701,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -722,7 +727,7 @@ class TestFunction:
         assert function["Configuration"]["Runtime"] == "java21"
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -757,14 +762,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -785,7 +790,7 @@ class TestFunction:
             assert function["Configuration"]["Layers"][i]["Arn"] == layers_list[i]
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -823,14 +828,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -851,7 +856,7 @@ class TestFunction:
         assert function_event_invoke_config["MaximumRetryAttempts"] == 2
         
         # Delete FunctionEventInvokeConfig
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["functionEventInvokeConfig"] =  None
 
         # Patch k8s resource
@@ -862,7 +867,7 @@ class TestFunction:
         assert not lambda_validator.get_function_event_invoke_config(resource_name)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -912,14 +917,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -945,7 +950,7 @@ class TestFunction:
         assert function["Configuration"]["CodeSha256"] == base64_hash_2
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -995,14 +1000,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -1030,7 +1035,7 @@ class TestFunction:
         assert function["Configuration"]["Architectures"] == ['arm64']
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -1066,14 +1071,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -1091,7 +1096,7 @@ class TestFunction:
         assert function["Configuration"]["TenancyConfig"]["TenantIsolationMode"] == "PER_TENANT"
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -1128,14 +1133,14 @@ class TestFunction:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 

--- a/test/e2e/tests/test_function_url_config.py
+++ b/test/e2e/tests/test_function_url_config.py
@@ -34,6 +34,11 @@ CREATE_WAIT_AFTER_SECONDS = 30
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 def get_testing_image_url():
     aws_region = get_region()
     account_id = get_account_id()
@@ -68,19 +73,19 @@ def lambda_function():
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         logging.debug(cr)
 
         yield (ref, cr)
 
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
 
@@ -112,7 +117,7 @@ class TestFunctionURLConfig:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -127,7 +132,7 @@ class TestFunctionURLConfig:
         assert function_url_config is not None
         assert function_url_config["AuthType"] == "NONE"
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         # Update cr
         cr["spec"]["cors"] = {
@@ -147,7 +152,7 @@ class TestFunctionURLConfig:
         assert function_url_config["Cors"]["AllowOrigins"] == ["https://*"]
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -180,7 +185,7 @@ class TestFunctionURLConfig:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
@@ -195,7 +200,7 @@ class TestFunctionURLConfig:
         assert function_url_config is not None
         assert function_url_config["AuthType"] == "NONE"
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         # Update cr
         cr["spec"]["cors"] = {
@@ -215,7 +220,7 @@ class TestFunctionURLConfig:
         assert function_url_config["Cors"]["AllowOrigins"] == ["https://*"]
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_layer_version.py
+++ b/test/e2e/tests/test_layer_version.py
@@ -34,6 +34,11 @@ CREATE_WAIT_AFTER_SECONDS = 10
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 @service_marker
 @pytest.mark.canary
 class TestLayerVersion:
@@ -63,14 +68,14 @@ class TestLayerVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -91,7 +96,7 @@ class TestLayerVersion:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         version_number = cr['status']['versionNumber']
 
         #Check layer version description
@@ -100,7 +105,7 @@ class TestLayerVersion:
         assert layer_version['Description'] == 'new description'
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         # Check if all versions are deleted

--- a/test/e2e/tests/test_version.py
+++ b/test/e2e/tests/test_version.py
@@ -36,6 +36,11 @@ CREATE_WAIT_AFTER_SECONDS = 10
 UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
 
+CONTROLLER_WAIT_PERIODS = 10
+CONTROLLER_PERIOD_LENGTH = 10
+DELETE_WAIT_PERIODS = 3
+DELETE_PERIOD_LENGTH = 10
+
 @pytest.fixture(scope="module")
 def lambda_function():
         resource_name = random_suffix_name("lambda-function", 24)
@@ -65,7 +70,7 @@ def lambda_function():
 
         # Create lambda function
         k8s.create_custom_resource(function_reference, resource_data)
-        function_resource = k8s.wait_resource_consumed_by_controller(function_reference)
+        function_resource = k8s.wait_resource_consumed_by_controller(function_reference, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert function_resource is not None
         assert k8s.get_resource_exists(function_reference)
@@ -74,7 +79,7 @@ def lambda_function():
 
         yield (function_reference, function_resource)
 
-        _, deleted = k8s.delete_custom_resource(function_reference)
+        _, deleted = k8s.delete_custom_resource(function_reference, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
 @service_marker
@@ -105,14 +110,14 @@ class TestVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -148,14 +153,14 @@ class TestVersion:
             resource_name_v2, namespace="default",
         )
         k8s.create_custom_resource(ref_v2, resource_data_v2)
-        cr_v2 = k8s.wait_resource_consumed_by_controller(ref_v2)
+        cr_v2 = k8s.wait_resource_consumed_by_controller(ref_v2, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr_v2 is not None
         assert k8s.get_resource_exists(ref_v2)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr_v2 = k8s.wait_resource_consumed_by_controller(ref_v2)
+        cr_v2 = k8s.wait_resource_consumed_by_controller(ref_v2, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -165,10 +170,10 @@ class TestVersion:
         assert lambda_validator.version_exists(lambda_function_name, version_number_2)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
-        _, deleted_2 = k8s.delete_custom_resource(ref_v2)
+        _, deleted_2 = k8s.delete_custom_resource(ref_v2, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted_2 is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -209,14 +214,14 @@ class TestVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -226,7 +231,7 @@ class TestVersion:
         assert lambda_validator.version_exists(lambda_function_name, version_number)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -257,14 +262,14 @@ class TestVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -273,7 +278,7 @@ class TestVersion:
         assert lambda_validator.version_exists(function_resource_name, version_number)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted is True
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -312,14 +317,14 @@ class TestVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -342,7 +347,7 @@ class TestVersion:
         assert function_event_invoke_config["MaximumRetryAttempts"] == 2
 
         # Delete FunctionEventInvokeConfig
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["functionEventInvokeConfig"] =  None
 
         # Patch k8s resource
@@ -353,7 +358,7 @@ class TestVersion:
         assert not lambda_validator.get_function_event_invoke_config_alias(lambda_function_name, version_number)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -389,14 +394,14 @@ class TestVersion:
             resource_name, namespace="default",
         )
         k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         assert cr is not None
         assert k8s.get_resource_exists(ref)
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
 
         lambda_validator = LambdaValidator(lambda_client)
 
@@ -417,7 +422,7 @@ class TestVersion:
         assert provisioned_concurrency_config["RequestedProvisionedConcurrentExecutions"] == 2
 
         # Delete provisioned_concurrency from version
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
         cr["spec"]["provisionedConcurrencyConfig"] = None
 
         # Patch k8s resource     
@@ -428,7 +433,7 @@ class TestVersion:
         assert not lambda_validator.get_provisioned_concurrency_config(lambda_function_name, version_number)
 
         # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
+        _, deleted = k8s.delete_custom_resource(ref, wait_periods=DELETE_WAIT_PERIODS, period_length=DELETE_PERIOD_LENGTH)
         assert deleted
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Under 33-way pytest-xdist parallel runs, controller reconciliation and resource deletion can exceed the acktest default timeouts (30s and 5s), causing non-deterministic test failures. Increase timeouts at call sites in all 7 lambda E2E test files without modifying acktest library defaults:

1. **Increase `wait_resource_consumed_by_controller` timeout at call sites**: Change all calls from `k8s.wait_resource_consumed_by_controller(ref)` (using defaults: 3 periods × 10s = 30s) to `k8s.wait_resource_consumed_by_controller(ref, wait_periods=10, period_length=10)` (10 periods × 10s = 100s). This provides ~3× headroom over the current 30s default for parallel execution.

2. **Increase `delete_custom_resource` timeout at call sites**: Change all calls from `k8s.delete_custom_resource(ref)` (using defaults: 1 period × 5s = 5s) to `k8s.delete_custom_resource(ref, wait_periods=3, period_length=10)` (3 periods × 10s = 30s). This provides 6× headroom over the current 5s default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
