### PR TITLE
fix: alias permissions silently dropped when statementID is nil

### DIFF
--- a/pkg/resource/alias/hooks.go
+++ b/pkg/resource/alias/hooks.go
@@ -442,13 +442,16 @@ func (rm *resourceManager) syncPermissions(
 	exit := rlog.Trace("rm.syncPermissions")
 	defer func() { exit(err) }()
 
+	for _, p := range desired.ko.Spec.Permissions {
+		if p.StatementID == nil || *p.StatementID == "" {
+			return ackerr.NewTerminalError(fmt.Errorf("permission is missing required field 'statementID'"))
+		}
+	}
+
 	toRemove, toAdd := comparePermissions(desired.ko.Spec.Permissions, latest.ko.Spec.Permissions)
 
 	// Process removals first to avoid conflicts
 	for _, p := range toRemove {
-		if p.StatementID == nil {
-			continue
-		}
 		rlog.Debug("removing permission", "statement_id", p.StatementID)
 		if err = rm.removePermission(ctx, desired, p.StatementID); err != nil {
 			return err
@@ -457,9 +460,6 @@ func (rm *resourceManager) syncPermissions(
 
 	// Then process additions
 	for _, p := range toAdd {
-		if p.StatementID == nil {
-			continue
-		}
 		rlog.Debug("adding permission", "statement_id", p.StatementID)
 		if err = rm.addPermission(ctx, desired, p); err != nil {
 			return err

--- a/test/e2e/tests/test_alias.py
+++ b/test/e2e/tests/test_alias.py
@@ -475,7 +475,28 @@ class TestAlias:
         # Verify permission2 was updated (need to examine contents)
         permission2_updated = False
         for statement in policy["Statement"]:
-            if (statement.get("Sid") == "permission2" and 
+            if (statement.get("Sid") == "permission2" and
                 "updated-rule" in statement.get("Condition", {}).get("ArnLike", {}).get("AWS:SourceArn", "")):
                 permission2_updated = True
         assert permission2_updated
+
+    def test_alias_permission_missing_statement_id(self, lambda_client, lambda_alias):
+        (ref, cr, lambda_function_name, resource_name) = lambda_alias
+
+        # Patch with a permission missing statementID
+        cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=CONTROLLER_WAIT_PERIODS, period_length=CONTROLLER_PERIOD_LENGTH)
+        cr["spec"]["permissions"] = [
+            {
+                "action": "lambda:InvokeFunction",
+                "principal": "events.amazonaws.com",
+            }
+        ]
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        assert k8s.assert_condition_state_message(
+            ref,
+            "ACK.Terminal",
+            "True",
+            "permission is missing required field 'statementID'",
+        )


### PR DESCRIPTION
Issue [#2659](https://github.com/aws-controllers-k8s/community/issues/2659)

Description of changes:
Permissions with nil statementID were excluded from comparison maps
and skipped during sync. Now they flow through to the AWS API which
returns the proper validation error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
