### PR TITLE
fix(lambda): remove empty DestinationConfig from EventSourceMapping

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-26T00:25:13Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
+  build_date: "2026-06-26T18:51:59Z"
+  build_hash: 016cc97b328515c8db205ad1091916a0cc66614b
   go_version: go1.26.4
-  version: v0.60.0
+  version: v0.60.0-2-g016cc97
 api_directory_checksum: ce4e1b9e43ddbbd1de4d42cb5734359c61a0040c
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: 84db182faab650d546e93c61de79c969df4a9c50
+  file_checksum: a44e7bd907fefe1b00641992a05da31c16efb5ab
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -253,6 +253,10 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/eventsourcemapping/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/eventsourcemapping/clean_destination_config.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/eventsourcemapping/clean_destination_config.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/eventsourcemapping/sdk_update_pre_build_request.go.tpl
       sdk_update_post_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -253,6 +253,10 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/eventsourcemapping/sdk_read_one_post_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/eventsourcemapping/clean_destination_config.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/eventsourcemapping/clean_destination_config.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/eventsourcemapping/sdk_update_pre_build_request.go.tpl
       sdk_update_post_build_request:

--- a/pkg/resource/event_source_mapping/sdk.go
+++ b/pkg/resource/event_source_mapping/sdk.go
@@ -384,6 +384,17 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+	if ko.Spec.DestinationConfig != nil {
+		if ko.Spec.DestinationConfig.OnFailure != nil && ko.Spec.DestinationConfig.OnFailure.Destination == nil {
+			ko.Spec.DestinationConfig.OnFailure = nil
+		}
+		if ko.Spec.DestinationConfig.OnSuccess != nil && ko.Spec.DestinationConfig.OnSuccess.Destination == nil {
+			ko.Spec.DestinationConfig.OnSuccess = nil
+		}
+		if ko.Spec.DestinationConfig.OnFailure == nil && ko.Spec.DestinationConfig.OnSuccess == nil {
+			ko.Spec.DestinationConfig = nil
+		}
+	}
 
 	return &resource{ko}, nil
 }
@@ -729,6 +740,18 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Spec.DestinationConfig != nil {
+		if ko.Spec.DestinationConfig.OnFailure != nil && ko.Spec.DestinationConfig.OnFailure.Destination == nil {
+			ko.Spec.DestinationConfig.OnFailure = nil
+		}
+		if ko.Spec.DestinationConfig.OnSuccess != nil && ko.Spec.DestinationConfig.OnSuccess.Destination == nil {
+			ko.Spec.DestinationConfig.OnSuccess = nil
+		}
+		if ko.Spec.DestinationConfig.OnFailure == nil && ko.Spec.DestinationConfig.OnSuccess == nil {
+			ko.Spec.DestinationConfig = nil
+		}
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -1326,6 +1349,18 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Spec.DestinationConfig != nil {
+		if ko.Spec.DestinationConfig.OnFailure != nil && ko.Spec.DestinationConfig.OnFailure.Destination == nil {
+			ko.Spec.DestinationConfig.OnFailure = nil
+		}
+		if ko.Spec.DestinationConfig.OnSuccess != nil && ko.Spec.DestinationConfig.OnSuccess.Destination == nil {
+			ko.Spec.DestinationConfig.OnSuccess = nil
+		}
+		if ko.Spec.DestinationConfig.OnFailure == nil && ko.Spec.DestinationConfig.OnSuccess == nil {
+			ko.Spec.DestinationConfig = nil
+		}
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/eventsourcemapping/clean_destination_config.go.tpl
+++ b/templates/hooks/eventsourcemapping/clean_destination_config.go.tpl
@@ -1,7 +1,3 @@
-	ko.Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))
-	if err != nil {
-		return nil, err
-	}
 	if ko.Spec.DestinationConfig != nil {
 		if ko.Spec.DestinationConfig.OnFailure != nil && ko.Spec.DestinationConfig.OnFailure.Destination == nil {
 			ko.Spec.DestinationConfig.OnFailure = nil


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2865

When creating an EventSourceMapping without specifying a DestinationConfig, the AWS Lambda API returns a DestinationConfig containing empty OnFailure or OnSuccess structs. The controller's ReadOne logic previously copied this empty structure into the resource's Spec, causing the Kubernetes API Server to persist the invalid empty config as a default value.

During subsequent reconciliations, the controller would then attempt to update the resource by sending this empty config back to AWS, resulting in an InvalidParameterValueException.

This fix injects hooks into the Create, ReadOne, and Update paths to detect and nil-out empty DestinationConfig blocks, preventing them from being saved to Kubernetes or sent to AWS.