### PR TITLE
Add cross-resource references to Function, Alias, FunctionUrlConfig and LayerVersion

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:37:28Z"
+  build_date: "2026-08-11T18:47:19Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: ce4e1b9e43ddbbd1de4d42cb5734359c61a0040c
+api_directory_checksum: 21c410a6036c64654a5de84675f482c71a51cb17
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: 84db182faab650d546e93c61de79c969df4a9c50
+  file_checksum: f7ec96705f45bb7c6d7c399b34cbb11d2370cdeb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-05T23:30:52Z"
+  build_date: "2026-08-11T21:44:35Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
   go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: ce4e1b9e43ddbbd1de4d42cb5734359c61a0040c
+api_directory_checksum: 5868fc26988d19c4bcd0d5b5c8185065082453ba
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: 84db182faab650d546e93c61de79c969df4a9c50
+  file_checksum: f7ec96705f45bb7c6d7c399b34cbb11d2370cdeb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-08-11T21:44:35Z"
+  build_date: "2026-08-11T21:59:48Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
   go_version: go1.26.0
   version: v0.62.0
@@ -7,7 +7,7 @@ api_directory_checksum: 5868fc26988d19c4bcd0d5b5c8185065082453ba
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.5
 generator_config_info:
-  file_checksum: f7ec96705f45bb7c6d7c399b34cbb11d2370cdeb
+  file_checksum: ea85efd6223acfed3d4ff9326facbf6aee9dc9f2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/alias.go
+++ b/apis/v1alpha1/alias.go
@@ -63,8 +63,8 @@ type AliasSpec struct {
 	// The function version that the alias invokes.
 	//
 	// Regex Pattern: `^(\$LATEST(\.PUBLISHED)?|[0-9]+)$`
-	// +kubebuilder:validation:Required
-	FunctionVersion *string `json:"functionVersion"`
+	FunctionVersion    *string                                  `json:"functionVersion,omitempty"`
+	FunctionVersionRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"functionVersionRef,omitempty"`
 	// The name of the alias.
 	//
 	// Regex Pattern: `^(?!^[0-9]+$)([a-zA-Z0-9-_]+)$`

--- a/apis/v1alpha1/function.go
+++ b/apis/v1alpha1/function.go
@@ -105,8 +105,9 @@ type FunctionSpec struct {
 	// or an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 	//
 	// Regex Pattern: `^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$`
-	KMSKeyARN *string                                  `json:"kmsKeyARN,omitempty"`
-	KMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsKeyRef,omitempty"`
+	KMSKeyARN *string                                    `json:"kmsKeyARN,omitempty"`
+	KMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper   `json:"kmsKeyRef,omitempty"`
+	LayerRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"layerRefs,omitempty"`
 	// A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
 	// to add to the function's execution environment. Specify each layer by its
 	// ARN, including the version.

--- a/apis/v1alpha1/function_url_config.go
+++ b/apis/v1alpha1/function_url_config.go
@@ -53,7 +53,8 @@ type FunctionURLConfigSpec struct {
 	// The alias name.
 	//
 	// Regex Pattern: `^((?!^\d+$)^[0-9a-zA-Z-_]+$)$`
-	Qualifier *string `json:"qualifier,omitempty"`
+	Qualifier    *string                                  `json:"qualifier,omitempty"`
+	QualifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"qualifierRef,omitempty"`
 }
 
 // FunctionURLConfigStatus defines the observed state of FunctionURLConfig

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -126,6 +126,9 @@ resources:
           - ignore: true
             method: ReadOne
       Layers:
+        references:
+          resource: LayerVersion
+          path: Status.ACKResourceMetadata.ARN
         set:
           - method: Create
             ignore: true
@@ -179,6 +182,9 @@ resources:
           path: Spec.Name
       FunctionVersion:
         is_required: true
+        references:
+          resource: Version
+          path: Status.Version
       FunctionEventInvokeConfig:
         from:
           operation: PutFunctionEventInvokeConfig
@@ -248,6 +254,12 @@ resources:
           resource: Secret
           service_name: secretsmanager
           path: Status.ACKResourceMetadata.ARN
+
+      SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI:
+        references:
+          resource: Secret
+          service_name: secretsmanager
+          path: Status.ACKResourceMetadata.ARN
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
@@ -266,6 +278,10 @@ resources:
           resource: Function
           path: Spec.Name
         is_primary_key: true
+      Qualifier:
+        references:
+          resource: Alias
+          path: Spec.Name
   LayerVersion:
     fields:
       LayerName:
@@ -275,9 +291,23 @@ resources:
         is_required: true
         compare:
           is_ignored: true
+        # PublishLayerVersion returns a LayerVersionContentOutput, which shares no
+        # members with the LayerVersionContentInput held in the spec, so the
+        # generated write-back replaces Spec.Content with an empty struct. That
+        # would drop the s3BucketRef companion below, so ignore Content on the
+        # response-consuming methods and keep the user's desired value.
         set:
           - ignore: true
             method: ReadOne
+          - ignore: true
+            method: Create
+          - ignore: true
+            method: Update
+      Content.S3Bucket:
+        references:
+          resource: Bucket
+          service_name: s3
+          path: Spec.Name
     tags:
       ignore: true
     hooks:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -254,12 +254,6 @@ resources:
           resource: Secret
           service_name: secretsmanager
           path: Status.ACKResourceMetadata.ARN
-
-      SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI:
-        references:
-          resource: Secret
-          service_name: secretsmanager
-          path: Status.ACKResourceMetadata.ARN
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -542,10 +542,12 @@ type Layer struct {
 // A ZIP archive that contains the contents of an Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // You can specify either an Amazon S3 location, or upload a layer archive directly.
 type LayerVersionContentInput struct {
-	S3Bucket        *string `json:"s3Bucket,omitempty"`
-	S3Key           *string `json:"s3Key,omitempty"`
-	S3ObjectVersion *string `json:"s3ObjectVersion,omitempty"`
-	ZipFile         []byte  `json:"zipFile,omitempty"`
+	S3Bucket *string `json:"s3Bucket,omitempty"`
+	// Reference field for S3Bucket
+	S3BucketRef     *ackv1alpha1.AWSResourceReferenceWrapper `json:"s3BucketRef,omitempty"`
+	S3Key           *string                                  `json:"s3Key,omitempty"`
+	S3ObjectVersion *string                                  `json:"s3ObjectVersion,omitempty"`
+	ZipFile         []byte                                   `json:"zipFile,omitempty"`
 }
 
 // Details about a version of an Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -307,6 +307,11 @@ func (in *AliasSpec) DeepCopyInto(out *AliasSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FunctionVersionRef != nil {
+		in, out := &in.FunctionVersionRef, &out.FunctionVersionRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)
@@ -2243,6 +2248,17 @@ func (in *FunctionSpec) DeepCopyInto(out *FunctionSpec) {
 		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LayerRefs != nil {
+		in, out := &in.LayerRefs, &out.LayerRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.Layers != nil {
 		in, out := &in.Layers, &out.Layers
 		*out = make([]*string, len(*in))
@@ -2555,6 +2571,11 @@ func (in *FunctionURLConfigSpec) DeepCopyInto(out *FunctionURLConfigSpec) {
 		in, out := &in.Qualifier, &out.Qualifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.QualifierRef != nil {
+		in, out := &in.QualifierRef, &out.QualifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -3073,6 +3094,11 @@ func (in *LayerVersionContentInput) DeepCopyInto(out *LayerVersionContentInput) 
 		in, out := &in.S3Bucket, &out.S3Bucket
 		*out = new(string)
 		**out = **in
+	}
+	if in.S3BucketRef != nil {
+		in, out := &in.S3BucketRef, &out.S3BucketRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.S3Key != nil {
 		in, out := &in.S3Key, &out.S3Key

--- a/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_aliases.yaml
@@ -139,6 +139,23 @@ spec:
 
                   Regex Pattern: `^(\$LATEST(\.PUBLISHED)?|[0-9]+)$`
                 type: string
+              functionVersionRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: |-
                   The name of the alias.
@@ -200,7 +217,6 @@ spec:
                     type: object
                 type: object
             required:
-            - functionVersion
             - name
             type: object
           status:

--- a/config/crd/bases/lambda.services.k8s.aws_functions.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functions.yaml
@@ -286,6 +286,25 @@ spec:
                         type: string
                     type: object
                 type: object
+              layerRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               layers:
                 description: |-
                   A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)

--- a/config/crd/bases/lambda.services.k8s.aws_functionurlconfigs.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_functionurlconfigs.yaml
@@ -116,6 +116,23 @@ spec:
 
                   Regex Pattern: `^((?!^\d+$)^[0-9a-zA-Z-_]+$)$`
                 type: string
+              qualifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - authType
             type: object

--- a/config/crd/bases/lambda.services.k8s.aws_layerversions.yaml
+++ b/config/crd/bases/lambda.services.k8s.aws_layerversions.yaml
@@ -59,6 +59,20 @@ spec:
                 properties:
                   s3Bucket:
                     type: string
+                  s3BucketRef:
+                    description: Reference field for S3Bucket
+                    properties:
+                      from:
+                        description: |-
+                          AWSResourceReference provides all the values necessary to reference another
+                          k8s resource for finding the identifier(Id/ARN/Name)
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                    type: object
                   s3Key:
                     type: string
                   s3ObjectVersion:

--- a/generator.yaml
+++ b/generator.yaml
@@ -126,6 +126,9 @@ resources:
           - ignore: true
             method: ReadOne
       Layers:
+        references:
+          resource: LayerVersion
+          path: Status.ACKResourceMetadata.ARN
         set:
           - method: Create
             ignore: true
@@ -179,6 +182,9 @@ resources:
           path: Spec.Name
       FunctionVersion:
         is_required: true
+        references:
+          resource: Version
+          path: Status.Version
       FunctionEventInvokeConfig:
         from:
           operation: PutFunctionEventInvokeConfig
@@ -248,6 +254,12 @@ resources:
           resource: Secret
           service_name: secretsmanager
           path: Status.ACKResourceMetadata.ARN
+
+      SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI:
+        references:
+          resource: Secret
+          service_name: secretsmanager
+          path: Status.ACKResourceMetadata.ARN
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
@@ -266,6 +278,10 @@ resources:
           resource: Function
           path: Spec.Name
         is_primary_key: true
+      Qualifier:
+        references:
+          resource: Alias
+          path: Spec.Name
   LayerVersion:
     fields:
       LayerName:
@@ -275,9 +291,23 @@ resources:
         is_required: true
         compare:
           is_ignored: true
+        # PublishLayerVersion returns a LayerVersionContentOutput, which shares no
+        # members with the LayerVersionContentInput held in the spec, so the
+        # generated write-back replaces Spec.Content with an empty struct. That
+        # would drop the s3BucketRef companion below, so ignore Content on the
+        # response-consuming methods and keep the user's desired value.
         set:
           - ignore: true
             method: ReadOne
+          - ignore: true
+            method: Create
+          - ignore: true
+            method: Update
+      Content.S3Bucket:
+        references:
+          resource: Bucket
+          service_name: s3
+          path: Spec.Name
     tags:
       ignore: true
     hooks:

--- a/generator.yaml
+++ b/generator.yaml
@@ -254,12 +254,6 @@ resources:
           resource: Secret
           service_name: secretsmanager
           path: Status.ACKResourceMetadata.ARN
-
-      SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI:
-        references:
-          resource: Secret
-          service_name: secretsmanager
-          path: Status.ACKResourceMetadata.ARN
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)

--- a/helm/crds/lambda.services.k8s.aws_aliases.yaml
+++ b/helm/crds/lambda.services.k8s.aws_aliases.yaml
@@ -139,6 +139,23 @@ spec:
 
                   Regex Pattern: `^(\$LATEST(\.PUBLISHED)?|[0-9]+)$`
                 type: string
+              functionVersionRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: |-
                   The name of the alias.
@@ -200,7 +217,6 @@ spec:
                     type: object
                 type: object
             required:
-            - functionVersion
             - name
             type: object
           status:

--- a/helm/crds/lambda.services.k8s.aws_functions.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functions.yaml
@@ -286,6 +286,25 @@ spec:
                         type: string
                     type: object
                 type: object
+              layerRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               layers:
                 description: |-
                   A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)

--- a/helm/crds/lambda.services.k8s.aws_functionurlconfigs.yaml
+++ b/helm/crds/lambda.services.k8s.aws_functionurlconfigs.yaml
@@ -116,6 +116,23 @@ spec:
 
                   Regex Pattern: `^((?!^\d+$)^[0-9a-zA-Z-_]+$)$`
                 type: string
+              qualifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - authType
             type: object

--- a/helm/crds/lambda.services.k8s.aws_layerversions.yaml
+++ b/helm/crds/lambda.services.k8s.aws_layerversions.yaml
@@ -59,6 +59,20 @@ spec:
                 properties:
                   s3Bucket:
                     type: string
+                  s3BucketRef:
+                    description: Reference field for S3Bucket
+                    properties:
+                      from:
+                        description: |-
+                          AWSResourceReference provides all the values necessary to reference another
+                          k8s resource for finding the identifier(Id/ARN/Name)
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                    type: object
                   s3Key:
                     type: string
                   s3ObjectVersion:

--- a/pkg/resource/alias/delta.go
+++ b/pkg/resource/alias/delta.go
@@ -125,6 +125,9 @@ func newResourceDelta(
 			delta.Add("Spec.FunctionVersion", a.ko.Spec.FunctionVersion, b.ko.Spec.FunctionVersion)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.FunctionVersionRef, b.ko.Spec.FunctionVersionRef) {
+		delta.Add("Spec.FunctionVersionRef", a.ko.Spec.FunctionVersionRef, b.ko.Spec.FunctionVersionRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {

--- a/pkg/resource/alias/references.go
+++ b/pkg/resource/alias/references.go
@@ -42,6 +42,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.FunctionName = nil
 	}
 
+	if ko.Spec.FunctionVersionRef != nil {
+		ko.Spec.FunctionVersion = nil
+	}
+
 	return &resource{ko}
 }
 
@@ -67,6 +71,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForFunctionVersion(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -79,6 +89,13 @@ func validateReferenceFields(ko *svcapitypes.Alias) error {
 	}
 	if ko.Spec.FunctionRef == nil && ko.Spec.FunctionName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionName", "FunctionRef")
+	}
+
+	if ko.Spec.FunctionVersionRef != nil && ko.Spec.FunctionVersion != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("FunctionVersion", "FunctionVersionRef")
+	}
+	if ko.Spec.FunctionVersionRef == nil && ko.Spec.FunctionVersion == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionVersion", "FunctionVersionRef")
 	}
 	return nil
 }
@@ -170,6 +187,97 @@ func getReferencedResourceState_Function(
 			"Function",
 			namespace, name,
 			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForFunctionVersion reads the resource referenced
+// from FunctionVersionRef field and sets the FunctionVersion
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForFunctionVersion(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Alias,
+) (hasReferences bool, err error) {
+	if ko.Spec.FunctionVersionRef != nil && ko.Spec.FunctionVersionRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.FunctionVersionRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: FunctionVersionRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Version{}
+		if err := getReferencedResourceState_Version(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.FunctionVersion = (*string)(obj.Status.Version)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Version looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Version(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Version,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Version",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Version",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Version",
+			namespace, name)
+	}
+	if obj.Status.Version == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Version",
+			namespace, name,
+			"Status.Version")
 	}
 	return nil
 }

--- a/pkg/resource/event_source_mapping/references.go
+++ b/pkg/resource/event_source_mapping/references.go
@@ -43,9 +43,6 @@ import (
 // +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers,verbs=get;list
 // +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers/status,verbs=get;list
 
-// +kubebuilder:rbac:groups=secretsmanager.services.k8s.aws,resources=secrets,verbs=get;list
-// +kubebuilder:rbac:groups=secretsmanager.services.k8s.aws,resources=secrets/status,verbs=get;list
-
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -73,16 +70,6 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if len(ko.Spec.QueueRefs) > 0 {
 		ko.Spec.Queues = nil
-	}
-
-	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
-		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
-			for f0idx, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
-				if f0iter.URIRef != nil {
-					ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs[f0idx].URI = nil
-				}
-			}
-		}
 	}
 
 	return &resource{ko}
@@ -128,12 +115,6 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	if fieldHasReferences, err := rm.resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -164,16 +145,6 @@ func validateReferenceFields(ko *svcapitypes.EventSourceMapping) error {
 
 	if len(ko.Spec.QueueRefs) > 0 && len(ko.Spec.Queues) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Queues", "QueueRefs")
-	}
-
-	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
-		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
-			for _, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
-				if f0iter.URIRef != nil && f0iter.URI != nil {
-					return ackerr.ResourceReferenceAndIDNotSupportedFor("SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI", "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef")
-				}
-			}
-		}
 	}
 	return nil
 }
@@ -551,47 +522,4 @@ func getReferencedResourceState_Broker(
 			"Status.BrokerID")
 	}
 	return nil
-}
-
-// resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI reads the resource referenced
-// from SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef field and sets the SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.EventSourceMapping,
-) (hasReferences bool, err error) {
-	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
-		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
-			for f0idx, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
-				if f0iter.URIRef != nil && f0iter.URIRef.From != nil {
-					hasReferences = true
-					arr := f0iter.URIRef.From
-					if arr.Name == nil || *arr.Name == "" {
-						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef")
-					}
-					namespace, err := ackrt.ResolveCrossNamespaceReference(
-						ctx,
-						rm.cfg.EnableCrossNamespace,
-						&ko.Status.Conditions,
-						ackrt.CrossNamespaceRefKindResource,
-						ko.ObjectMeta.GetNamespace(),
-						arr.Namespace,
-						*arr.Name,
-					)
-					if err != nil {
-						return hasReferences, err
-					}
-					obj := &secretsmanagerapitypes.Secret{}
-					if err := getReferencedResourceState_Secret(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-						return hasReferences, err
-					}
-					ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs[f0idx].URI = (*string)(obj.Status.ACKResourceMetadata.ARN)
-				}
-			}
-		}
-	}
-
-	return hasReferences, nil
 }

--- a/pkg/resource/event_source_mapping/references.go
+++ b/pkg/resource/event_source_mapping/references.go
@@ -43,6 +43,9 @@ import (
 // +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers,verbs=get;list
 // +kubebuilder:rbac:groups=mq.services.k8s.aws,resources=brokers/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=secretsmanager.services.k8s.aws,resources=secrets,verbs=get;list
+// +kubebuilder:rbac:groups=secretsmanager.services.k8s.aws,resources=secrets/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -70,6 +73,16 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if len(ko.Spec.QueueRefs) > 0 {
 		ko.Spec.Queues = nil
+	}
+
+	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
+		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
+			for f0idx, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
+				if f0iter.URIRef != nil {
+					ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs[f0idx].URI = nil
+				}
+			}
+		}
 	}
 
 	return &resource{ko}
@@ -115,6 +128,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -145,6 +164,16 @@ func validateReferenceFields(ko *svcapitypes.EventSourceMapping) error {
 
 	if len(ko.Spec.QueueRefs) > 0 && len(ko.Spec.Queues) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Queues", "QueueRefs")
+	}
+
+	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
+		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
+			for _, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
+				if f0iter.URIRef != nil && f0iter.URI != nil {
+					return ackerr.ResourceReferenceAndIDNotSupportedFor("SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI", "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef")
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -522,4 +551,47 @@ func getReferencedResourceState_Broker(
 			"Status.BrokerID")
 	}
 	return nil
+}
+
+// resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI reads the resource referenced
+// from SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef field and sets the SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSelfManagedKafkaEventSourceConfig_SchemaRegistryConfig_AccessConfigs_URI(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.EventSourceMapping,
+) (hasReferences bool, err error) {
+	if ko.Spec.SelfManagedKafkaEventSourceConfig != nil {
+		if ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig != nil {
+			for f0idx, f0iter := range ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs {
+				if f0iter.URIRef != nil && f0iter.URIRef.From != nil {
+					hasReferences = true
+					arr := f0iter.URIRef.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URIRef")
+					}
+					namespace, err := ackrt.ResolveCrossNamespaceReference(
+						ctx,
+						rm.cfg.EnableCrossNamespace,
+						&ko.Status.Conditions,
+						ackrt.CrossNamespaceRefKindResource,
+						ko.ObjectMeta.GetNamespace(),
+						arr.Namespace,
+						*arr.Name,
+					)
+					if err != nil {
+						return hasReferences, err
+					}
+					obj := &secretsmanagerapitypes.Secret{}
+					if err := getReferencedResourceState_Secret(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					ko.Spec.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs[f0idx].URI = (*string)(obj.Status.ACKResourceMetadata.ARN)
+				}
+			}
+		}
+	}
+
+	return hasReferences, nil
 }

--- a/pkg/resource/function/delta.go
+++ b/pkg/resource/function/delta.go
@@ -260,6 +260,9 @@ func newResourceDelta(
 	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef) {
 		delta.Add("Spec.KMSKeyRef", a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef)
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.LayerRefs, b.ko.Spec.LayerRefs) {
+		delta.Add("Spec.LayerRefs", a.ko.Spec.LayerRefs, b.ko.Spec.LayerRefs)
+	}
 	if len(a.ko.Spec.Layers) != len(b.ko.Spec.Layers) {
 		delta.Add("Spec.Layers", a.ko.Spec.Layers, b.ko.Spec.Layers)
 	} else if len(a.ko.Spec.Layers) > 0 {

--- a/pkg/resource/function/references.go
+++ b/pkg/resource/function/references.go
@@ -71,6 +71,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.KMSKeyARN = nil
 	}
 
+	if len(ko.Spec.LayerRefs) > 0 {
+		ko.Spec.Layers = nil
+	}
+
 	if ko.Spec.RoleRef != nil {
 		ko.Spec.Role = nil
 	}
@@ -124,6 +128,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForLayers(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForRole(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -161,6 +171,10 @@ func validateReferenceFields(ko *svcapitypes.Function) error {
 
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyARN != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyARN", "KMSKeyRef")
+	}
+
+	if len(ko.Spec.LayerRefs) > 0 && len(ko.Spec.Layers) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Layers", "LayerRefs")
 	}
 
 	if ko.Spec.RoleRef != nil && ko.Spec.Role != nil {
@@ -453,6 +467,102 @@ func getReferencedResourceState_Key(
 	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"Key",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForLayers reads the resource referenced
+// from LayerRefs field and sets the Layers
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForLayers(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Function,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.LayerRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: LayerRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &svcapitypes.LayerVersion{}
+			if err := getReferencedResourceState_LayerVersion(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.Layers == nil {
+				ko.Spec.Layers = make([]*string, 0, 1)
+			}
+			ko.Spec.Layers = append(ko.Spec.Layers, (*string)(obj.Status.ACKResourceMetadata.ARN))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_LayerVersion looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_LayerVersion(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.LayerVersion,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"LayerVersion",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"LayerVersion",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"LayerVersion",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"LayerVersion",
 			namespace, name,
 			"Status.ACKResourceMetadata.ARN")
 	}

--- a/pkg/resource/function_url_config/delta.go
+++ b/pkg/resource/function_url_config/delta.go
@@ -112,6 +112,9 @@ func newResourceDelta(
 			delta.Add("Spec.Qualifier", a.ko.Spec.Qualifier, b.ko.Spec.Qualifier)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.QualifierRef, b.ko.Spec.QualifierRef) {
+		delta.Add("Spec.QualifierRef", a.ko.Spec.QualifierRef, b.ko.Spec.QualifierRef)
+	}
 
 	return delta
 }

--- a/pkg/resource/function_url_config/references.go
+++ b/pkg/resource/function_url_config/references.go
@@ -42,6 +42,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.FunctionName = nil
 	}
 
+	if ko.Spec.QualifierRef != nil {
+		ko.Spec.Qualifier = nil
+	}
+
 	return &resource{ko}
 }
 
@@ -67,6 +71,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForQualifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -79,6 +89,10 @@ func validateReferenceFields(ko *svcapitypes.FunctionURLConfig) error {
 	}
 	if ko.Spec.FunctionRef == nil && ko.Spec.FunctionName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("FunctionName", "FunctionRef")
+	}
+
+	if ko.Spec.QualifierRef != nil && ko.Spec.Qualifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Qualifier", "QualifierRef")
 	}
 	return nil
 }
@@ -168,6 +182,97 @@ func getReferencedResourceState_Function(
 	if obj.Spec.Name == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"Function",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForQualifier reads the resource referenced
+// from QualifierRef field and sets the Qualifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForQualifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.FunctionURLConfig,
+) (hasReferences bool, err error) {
+	if ko.Spec.QualifierRef != nil && ko.Spec.QualifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.QualifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: QualifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Alias{}
+		if err := getReferencedResourceState_Alias(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.Qualifier = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Alias looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Alias(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Alias,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Alias",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Alias",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Alias",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Alias",
 			namespace, name,
 			"Spec.Name")
 	}

--- a/pkg/resource/layer_version/references.go
+++ b/pkg/resource/layer_version/references.go
@@ -17,13 +17,23 @@ package layer_version
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	s3apitypes "github.com/aws-controllers-k8s/s3-controller/apis/v1alpha1"
 
 	svcapitypes "github.com/aws-controllers-k8s/lambda-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets,verbs=get;list
+// +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -31,6 +41,12 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.Content != nil {
+		if ko.Spec.Content.S3BucketRef != nil {
+			ko.Spec.Content.S3Bucket = nil
+		}
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +63,120 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForContent_S3Bucket(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.LayerVersion) error {
+
+	if ko.Spec.Content != nil {
+		if ko.Spec.Content.S3BucketRef != nil && ko.Spec.Content.S3Bucket != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("Content.S3Bucket", "Content.S3BucketRef")
+		}
+	}
+	return nil
+}
+
+// resolveReferenceForContent_S3Bucket reads the resource referenced
+// from Content.S3BucketRef field and sets the Content.S3Bucket
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForContent_S3Bucket(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.LayerVersion,
+) (hasReferences bool, err error) {
+	if ko.Spec.Content != nil {
+		if ko.Spec.Content.S3BucketRef != nil && ko.Spec.Content.S3BucketRef.From != nil {
+			hasReferences = true
+			arr := ko.Spec.Content.S3BucketRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: Content.S3BucketRef")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &s3apitypes.Bucket{}
+			if err := getReferencedResourceState_Bucket(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.Content.S3Bucket = (*string)(obj.Spec.Name)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Bucket looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Bucket(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *s3apitypes.Bucket,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Bucket",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Bucket",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Bucket",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Bucket",
+			namespace, name,
+			"Spec.Name")
+	}
 	return nil
 }

--- a/pkg/resource/layer_version/sdk.go
+++ b/pkg/resource/layer_version/sdk.go
@@ -222,12 +222,6 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Spec.CompatibleRuntimes = nil
 	}
-	if resp.Content != nil {
-		f2 := &svcapitypes.LayerVersionContentInput{}
-		ko.Spec.Content = f2
-	} else {
-		ko.Spec.Content = nil
-	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = resp.CreatedDate
 	} else {
@@ -366,12 +360,6 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Spec.CompatibleRuntimes = f1
 	} else {
 		ko.Spec.CompatibleRuntimes = nil
-	}
-	if resp.Content != nil {
-		f2 := &svcapitypes.LayerVersionContentInput{}
-		ko.Spec.Content = f2
-	} else {
-		ko.Spec.Content = nil
 	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = resp.CreatedDate


### PR DESCRIPTION
Adds cross-resource references to 4 fields across 4 resources in `lambda-controller`.

These come from a fleet-wide audit for CRD spec fields that hold another AWS resource's identifier but have no `references` block, each of which forces a user to hardcode an ARN, ID, or name they cannot know until the other resource exists.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `Function.Layers` | lambda `LayerVersion` (same service) | `Status.ACKResourceMetadata.ARN` |
| 2 | `Alias.FunctionVersion` | lambda `Version` (same service) | `Status.Version` |
| 3 | `FunctionUrlConfig.Qualifier` | lambda `Alias` (same service) | `Spec.Name` |
| 4 | `LayerVersion.Content.S3Bucket` | s3 `Bucket` | `Spec.Name` |

Notes on individual fields:

- **(1) `Function.Layers`** requires the versioned layer ARN ("Specify each layer by its ARN, including the version"). `LayerVersion` sets `ACKResourceMetadata.ARN` from `LayerVersionArn`, which carries the trailing version; `Status.LayerARN` is the *unversioned* ARN and would be the wrong choice. The field already carried `set: ignore` on Create and ReadOne, with `LayerStatuses` as the read-only echo, so the new `layerRefs` companion is not clobbered by the response.
- **(2) `Alias.FunctionVersion`** holds the bare numeric version (`pattern: ^(\$LATEST(\.PUBLISHED)?|[0-9]+)$`), not an ARN, so it targets `Status.Version` on `Version`. Being API-required, the field correctly leaves the CRD `required` list now that either form is acceptable. `$LATEST` remains expressible through the concrete field.
- **(3) `FunctionUrlConfig.Qualifier`** is documented as "The alias name" and its pattern (`^((?!^\d+$)^[0-9a-zA-Z-_]+$)$`) rejects an all-digits value, ruling out a version number and leaving an alias name as the only legal content — hence `Spec.Name` on `Alias`.
- **(4) `LayerVersion.Content.S3Bucket`** mirrors `Function.Code.S3Bucket`, already wired to s3 `Bucket` at `Spec.Name`. **This one needed more than a `references` block:** `PublishLayerVersion` returns a `LayerVersionContentOutput` that shares no members with the `LayerVersionContentInput` held in the spec, so the generated write-back replaced `Spec.Content` with an *empty struct* and would have dropped the new `s3BucketRef` on the first reconcile. `set: ignore` is therefore added for Create and Update (ReadOne was already ignored). `Content` is user-supplied with no server default, so no `late_initialize` is needed. Side benefit: a `LayerVersion` created with a concrete `content.s3Bucket` now keeps it in `.spec` instead of having it wiped to `{}` after create.

No new module dependency: `s3-controller` is already required by the existing `Function.Code.S3Bucket` reference, so `go.mod` is unchanged and `ATTRIBUTION.md` does not need regenerating.

### Verification

Deployed this branch to `ack-dev-auto` (`us-west-2`) with a 60s resync period (`ack-workspace deploy lambda --resync-period 60`), alongside `s3-controller` for the cross-service target, and tested each field. PASS requires all four conditions, held delta-free across at least 3 reconciles: `ACK.ReferencesResolved=True`, `ACK.ResourceSynced=True`, concrete field absent from `.spec`, `*Ref` present in `.spec`.

| # | Resource.field | RefsResolved | Synced | Concrete absent | `*Ref` present | Deltas / 4 resyncs | Result |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `Function.layerRefs` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 2 | `Alias.functionVersionRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 3 | `FunctionUrlConfig.qualifierRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 4 | `LayerVersion.content.s3BucketRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |

**Summary: 4/4 PASS** — resync period 60s, delta-free across 4 reconciles.

Each reference was additionally confirmed against AWS rather than only against the CR, since three of these paths are echoed back in a form that would expose a wrong `path`:

- **(1)** `status.layerStatuses[0].arn` = `arn:aws:lambda:us-west-2:…:layer:ack-ref-test-layer:1` — the **versioned** ARN reached AWS and was attached, which is what `Status.ACKResourceMetadata.ARN` resolves to. `Status.LayerARN` would have produced the unversioned form and been rejected.
- **(2)** `aws lambda get-alias` returns `FunctionVersion = 1` — the bare version string was sent, not an ARN. Note `Version.status.version = "1"` while `status.qualifier` is `null`, confirming `Status.Version` is the populated field and the right choice of `path`.
- **(3)** `status.functionARN` = `…function:ack-ref-test-fn:ack-ref-test-alias` — the URL is scoped to the referenced alias. `GetFunctionUrlConfig` does not echo `Qualifier`, so this is the only way to observe that the resolved alias name was sent.
- **(4)** The layer published successfully from the referenced bucket (`…layer:ack-ref-test-layer:1`), which is the available signal because `Content` is write-only.

**The zero-delta counts are not vacuous.** With no delta the runtime logs nothing per reconcile, so the log signal was proven live by injecting drift out-of-band (`aws lambda update-function-configuration --description …`). The controller detected it 33s later, logged `desired resource state has changed` with `diff paths: [['Spec','Description']]`, and reverted it. So reconciles were running during the measurement window and the delta log appears when there is one — the only diff observed on any test resource was the injected one, never a reference field.

<details>
<summary>Test manifests and observed state</summary>

Reference chain: s3 `Bucket` → `LayerVersion` → `Function` → `Version` → `Alias` → `FunctionUrlConfig`. Every manifest sets the `*Ref` and omits the concrete field.

```yaml
apiVersion: lambda.services.k8s.aws/v1alpha1
kind: LayerVersion
metadata:
  name: ack-ref-test-layer
spec:
  layerName: ack-ref-test-layer
  compatibleRuntimes: [python3.12]
  content:
    s3BucketRef:                      # gap 4; content.s3Bucket omitted
      from:
        name: ack-lambda-ref-test-bucket
    s3Key: layer.zip
---
apiVersion: lambda.services.k8s.aws/v1alpha1
kind: Function
metadata:
  name: ack-ref-test-fn
spec:
  name: ack-ref-test-fn
  role: arn:aws:iam::…:role/ref-test-lambda-role
  runtime: python3.12
  handler: lambda_function.handler
  code:
    s3BucketRef:
      from:
        name: ack-lambda-ref-test-bucket
    s3Key: fn.zip
  layerRefs:                          # gap 1; spec.layers omitted
    - from:
        name: ack-ref-test-layer
---
apiVersion: lambda.services.k8s.aws/v1alpha1
kind: Alias
metadata:
  name: ack-ref-test-alias
spec:
  name: ack-ref-test-alias
  functionRef:
    from:
      name: ack-ref-test-fn
  functionVersionRef:                 # gap 2; spec.functionVersion omitted
    from:
      name: ack-ref-test-version
---
apiVersion: lambda.services.k8s.aws/v1alpha1
kind: FunctionURLConfig
metadata:
  name: ack-ref-test-furl
spec:
  functionRef:
    from:
      name: ack-ref-test-fn
  qualifierRef:                       # gap 3; spec.qualifier omitted
    from:
      name: ack-ref-test-alias
  authType: NONE
```

Observed state — conditions, concrete field absent, `*Ref` present:

```
--- layerversion/ack-ref-test-layer
{"refsResolved":"True","synced":"True","concrete":null,"ref":{"from":{"name":"ack-lambda-ref-test-bucket"}}}
--- function/ack-ref-test-fn
{"refsResolved":"True","synced":"True","concrete":null,"ref":[{"from":{"name":"ack-ref-test-layer"}}]}
--- alias.lambda.services.k8s.aws/ack-ref-test-alias
{"refsResolved":"True","synced":"True","concrete":null,"ref":{"from":{"name":"ack-ref-test-version"}}}
--- functionurlconfig/ack-ref-test-furl
{"refsResolved":"True","synced":"True","concrete":null,"ref":{"from":{"name":"ack-ref-test-alias"}}}
```

AWS-side confirmation:

```
$ kubectl get layerversion ack-ref-test-layer -o json | jq -c '.status'
{"arn":"arn:aws:lambda:us-west-2:…:layer:ack-ref-test-layer:1","versionNumber":1}

$ kubectl get function ack-ref-test-fn -o json | jq -c '.status.layerStatuses'
[{"arn":"arn:aws:lambda:us-west-2:…:layer:ack-ref-test-layer:1","codeSize":343}]

$ aws lambda get-alias --function-name ack-ref-test-fn --name ack-ref-test-alias \
    --query '[FunctionVersion,AliasArn]' --output text
1   arn:aws:lambda:us-west-2:…:function:ack-ref-test-fn:ack-ref-test-alias

$ kubectl get functionurlconfig ack-ref-test-furl -o json | jq -c '.status'
{"functionARN":"arn:aws:lambda:us-west-2:…:function:ack-ref-test-fn:ack-ref-test-alias",
 "functionURL":"https://….lambda-url.us-west-2.on.aws/"}
```

Delta window (resync 60s, 21:35:55Z → 21:40:35Z, 4 resyncs):

```
ack-ref-test-layer: 0
ack-ref-test-layer-concrete: 0
ack-ref-test-fn: 0
ack-ref-test-version: 0
ack-ref-test-alias: 0
ack-ref-test-furl: 0
```

Drift-injection control, proving the delta log is live and reconciles were running:

```
$ aws lambda update-function-configuration --function-name ack-ref-test-fn \
    --description "DRIFT-INJECTED-1786483918"
# 33s later:
{"level":"info","ts":"2026-08-11T21:32:32.839Z","logger":"ackrt",
 "msg":"desired resource state has changed","kind":"Function","name":"ack-ref-test-fn",
 "generation":2,"diff":[{"Path":{"Parts":["Spec","Description"]} ...
diff paths: [['Spec', 'Description']]
$ aws lambda get-function-configuration --function-name ack-ref-test-fn --query Description
reference audit remediation test function      # reverted
```

Input matrix for gap 4 (`LayerVersion.Content.S3Bucket`), which carries the `set: ignore` change:

| Input | Result |
| --- | --- |
| `s3BucketRef` supplied, concrete omitted | `Synced=True`, ref preserved in `.spec`, concrete absent, layer published from the referenced bucket |
| concrete `s3Bucket` supplied, no ref | `Synced=True`, `.spec.content` retains `{"s3Bucket":"…","s3Key":"layer.zip"}` and publishes — previously this was wiped to `{}` after create |
| neither | n/a — `Content` is API-required and has no server default, so there is nothing to late-initialize |

</details>

### Audit findings deliberately *not* wired

Four further fields on these resources hold another resource's identifier but are **polymorphic** — they accept more than one resource type. The code-generator takes exactly one `resource` per field and the generated resolver instantiates one concrete Kind, so wiring one arm would privilege it invisibly, and because the ref/concrete choice is per field, it would lock out any user needing a mixed-type list. Reported here so these are not read as overlooked, with the alternatives enumerated for whoever decides how to express unions:

| Field | Accepted types |
| --- | --- |
| `Function.DeadLetterConfig.TargetARN` | sqs `Queue`, sns `Topic` |
| `Function.FileSystemConfigs.ARN` | efs `AccessPoint`, s3files `AccessPoint` (the validation pattern admits both) |
| `EventSourceMapping.SourceAccessConfigurations.URI` | secretsmanager `Secret`, ec2 `Subnet`, ec2 `SecurityGroup`, or a plain RabbitMQ virtual-host name — selected by the sibling `type_` |
| `{Function,Alias,Version}.FunctionEventInvokeConfig.DestinationConfig.On{Failure,Success}.Destination` | sns `Topic`, sqs `Queue`, s3 `Bucket`, lambda `Function`, eventbridge `EventBus` |

The concrete field already accepts every one of these types, so omitting the reference costs users nothing they have today.

Three further items surfaced and are **out of scope**, each deserving its own change:

- **`EventSourceMapping.SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI`** → secretsmanager `Secret`. This was wired in an earlier revision of this PR and has been **removed again**, because it cannot be verified end to end. The reference resolves correctly, but the resource can never reach `Synced`: the API rejects it with `SchemaRegistryConfig is only available for Provisioned Mode. To configure Schema Registry, please enable Provisioned Mode by specifying MinimumPollers in ProvisionedPollerConfig`, and `ProvisionedPollerConfig` is held out of the CRD by `ignore.field_paths`, so `MinimumPollers` is unreachable through this controller. Worth noting for whoever picks this up: because both Kafka branches share the `KafkaSchemaRegistryAccessConfig` shape, the CRD already advertises `selfManagedKafkaEventSourceConfig.…accessConfigs[].uriRef` today with no resolver behind it, so setting it is currently silently ignored. Un-suppressing `ProvisionedPollerConfig` and adding the resolver belong together in one change — which would also make the already-merged `AmazonManagedKafka` twin usable, since it is blocked by the same gate.
- **`Function.LoggingConfig.LogGroup`** → cloudwatchlogs `LogGroup` is a genuine, monomorphic gap. `sdkCreate` writes `Spec.LoggingConfig` back, so it needs `set: ignore`, which in turn stops the server-side defaults for the three sibling enum leaves (`LogFormat`, `ApplicationLogLevel`, `SystemLogLevel`) from landing in the spec and requires a `late_initialize`/`skip_incomplete_check` cascade across the whole struct. That changes convergence behaviour for every existing `Function` and adds a new `cloudwatchlogs-controller` dependency.
- **`FunctionCode.SourceKMSKeyArn`** and **`CreateEventSourceMappingInput.KMSKeyArn`** are both suppressed via `ignore.field_paths` and are textbook kms `Key` references. They cannot be fixed with a `references` block while suppressed; un-ignoring them is a separate, larger change.

### Checklist

- [x] Workspace refreshed (runtime, code-generator, controller) before generating
- [x] `service_name` omitted for same-service targets, set for cross-service
- [x] `path` matches the form the resource's Describe response returns
- [x] Regenerated with `ack-workspace build lambda`; controller compiles
- [x] Generated artifacts committed (`apis/`, `pkg/resource/`, `config/crd/`, `helm/`)
- [x] `go.mod` updated and pinned (cross-service only) — n/a, no new dependency
- [x] `ATTRIBUTION.md` regenerated (cross-service only) — n/a, no new dependency
- [x] All 4 fields verified against the four pass criteria, delta-free across 4 reconciles

/label release/minor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
